### PR TITLE
Fix SDL2 audio, chat crash, and client robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,7 @@ compile_commands.json
 Thumbs.db
 *.swp
 *.swo
+
+# Local runtime-generated files
+/eglcfg.cfg
+/console.log

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,24 @@
 # Basic Makefile for EGL Quake 2 on MinGW (Windows)
+CC ?= gcc
+
+# Some Windows environments set CC=cc by default, but don't actually provide a 'cc' executable.
+# If the caller wants a specific compiler, they can still override CC on the command line.
+ifeq ($(CC),cc)
 CC = gcc
+endif
 
 # Optional SDL2 backend (set USE_SDL2=1 to enable)
 ifdef USE_SDL2
-CFLAGS += -DHAVE_SDL2
-LDFLAGS += -lSDL2
+# Allow overriding MSYS2 location/prefix via env or make vars.
+MSYS2_ROOT ?= $(or $(EGL_MSYS2_ROOT),C:/msys64)
+MSYS2_PREFIX ?= $(or $(EGL_MSYS2_PREFIX),mingw64)
+
+SDL2_INC_DIR = $(MSYS2_ROOT)/$(MSYS2_PREFIX)/include/SDL2
+SDL2_LIB_DIR = $(MSYS2_ROOT)/$(MSYS2_PREFIX)/lib
+SDL2_DLL_SRC = $(MSYS2_ROOT)/$(MSYS2_PREFIX)/bin/SDL2.dll
+
+CFLAGS += -DHAVE_SDL2 -I"$(SDL2_INC_DIR)"
+LDFLAGS += -L"$(SDL2_LIB_DIR)" -lSDL2
 SDL2_SOURCES = sdl2/sdl_glimp.c sdl2/sdl_input.c sdl2/sdl_snd.c sdl2/sdl_main.c
 else
 SDL2_SOURCES =
@@ -69,6 +83,9 @@ debug:
 
 egl.exe: $(COMMON_OBJ) $(CLIENT_OBJ) $(RENDERER_OBJ) $(SERVER_OBJ)
 	$(CC) -o $@ $^ $(LDFLAGS)
+ifdef USE_SDL2
+	-powershell -NoProfile -Command "if (Test-Path -LiteralPath '$(SDL2_DLL_SRC)') { Copy-Item -Force -LiteralPath '$(SDL2_DLL_SRC)' -Destination 'SDL2.dll' } else { throw 'SDL2.dll not found at $(SDL2_DLL_SRC). Install MSYS2 SDL2 for your prefix (e.g. mingw-w64-x86_64-SDL2) or set EGL_MSYS2_ROOT/EGL_MSYS2_PREFIX.' }"
+endif
 
 $(CGAME_DLL): $(CGAME_OBJ) $(SHARED_OBJ) cgame/exports.def
 	$(CC) -o $@ $(DLL_LDFLAGS) $(CGAME_OBJ) $(SHARED_OBJ) cgame/exports.def

--- a/Makefile.unix
+++ b/Makefile.unix
@@ -73,6 +73,11 @@ SERVER_OBJ = $(SERVER_SRC:.c=.o)
 UNIX_CLIENT_OBJ = $(UNIX_CLIENT_SRC:.c=.o)
 UNIX_DED_OBJ = $(UNIX_DED_SRC:.c=.o)
 
+# Dedicated-only object lists (compiled with DED_CFLAGS)
+DED_COMMON_OBJ = $(COMMON_SRC:.c=.ded.o)
+DED_SERVER_OBJ = $(SERVER_SRC:.c=.ded.o)
+DED_UNIX_DED_OBJ = $(UNIX_DED_SRC:.c=.ded.o)
+
 # Output names (Unix module loader expects game.so / eglcgame.so on non-i386)
 CGAME_SO = eglcgame.so
 GAME_SO = game.so
@@ -88,7 +93,7 @@ egl: $(CLIENT_OBJ) $(RENDERER_OBJ) $(SERVER_OBJ) $(UNIX_CLIENT_OBJ) $(COMMON_OBJ
 
 dedicated: eglded
 
-eglded: $(COMMON_OBJ) $(SERVER_OBJ) $(UNIX_DED_OBJ)
+eglded: $(DED_COMMON_OBJ) $(DED_SERVER_OBJ) $(DED_UNIX_DED_OBJ)
 	$(CC) -o $@ $^ $(DED_LDFLAGS)
 
 modules: $(CGAME_SO) $(GAME_SO)
@@ -105,6 +110,9 @@ $(GAME_SO): $(GAME_OBJ:.o=.pic.o) $(SHARED_SRC:.c=.pic.o)
 # Pattern rules
 %.o: %.c
 	$(CC) $(CFLAGS_COMMON) -c $< -o $@
+
+%.ded.o: %.c
+	$(CC) $(DED_CFLAGS) -c $< -o $@
 
 %.pic.o: %.c
 	$(CC) $(SO_CFLAGS) -c $< -o $@

--- a/cgame/cg_main.c
+++ b/cgame/cg_main.c
@@ -588,13 +588,16 @@ CG_Init
 void CG_Init (void)
 {
 	char	*gameDir;
+	Com_DevPrintf (0, "[cginit] CG_Init begin\n");
 
 	// Clear everything
 	memset (&cg, 0, sizeof (cgState_t));
 	memset (&cgMedia, 0, sizeof (cgMedia_t));
 	memset (&uiMedia, 0, sizeof (uiMedia));
+	Com_DevPrintf (0, "[cginit] cleared state\n");
 
 	CG_ClearEntities ();
+	Com_DevPrintf (0, "[cginit] CG_ClearEntities done\n");
 
 	// This nastiness is done because I don't
 	// feel like compiling several cgame libraries...
@@ -613,32 +616,54 @@ void CG_Init (void)
 		cg.currGameMod = GAME_MOD_XATRIX;
 	else
 		cg.currGameMod = GAME_MOD_DEFAULT;
+	Com_DevPrintf (0, "[cginit] game mod detected (%d)\n", cg.currGameMod);
 
 	// Update refConfig
+	Com_DevPrintf (0, "[cginit] before R_GetRefConfig\n");
 	cgi.R_GetRefConfig (&cg.refConfig);
+	Com_DevPrintf (0, "[cginit] after R_GetRefConfig (%dx%d)\n", cg.refConfig.vidWidth, cg.refConfig.vidHeight);
 
 	// Copy config strings
+	Com_DevPrintf (0, "[cginit] before CG_CopyConfigStrings\n");
 	CG_CopyConfigStrings ();
+	Com_DevPrintf (0, "[cginit] after CG_CopyConfigStrings\n");
 
 	// Initialize early needed media
+	Com_DevPrintf (0, "[cginit] before CG_InitBaseMedia\n");
 	CG_InitBaseMedia ();
+	Com_DevPrintf (0, "[cginit] after CG_InitBaseMedia\n");
 
 	// Register cvars and commands
+	Com_DevPrintf (0, "[cginit] before V_Register\n");
 	V_Register ();
+	Com_DevPrintf (0, "[cginit] after V_Register\n");
+	Com_DevPrintf (0, "[cginit] before CG_WeapRegister\n");
 	CG_WeapRegister ();
+	Com_DevPrintf (0, "[cginit] after CG_WeapRegister\n");
+	Com_DevPrintf (0, "[cginit] before CG_RegisterMain\n");
 	CG_RegisterMain ();
+	Com_DevPrintf (0, "[cginit] after CG_RegisterMain\n");
 
 	// Check cvar sanity
+	Com_DevPrintf (0, "[cginit] before CG_UpdateCvars\n");
 	CG_UpdateCvars (qTrue);
+	Com_DevPrintf (0, "[cginit] after CG_UpdateCvars\n");
 
 	// Location system init
+	Com_DevPrintf (0, "[cginit] before CG_LocationInit\n");
 	CG_LocationInit ();
+	Com_DevPrintf (0, "[cginit] after CG_LocationInit\n");
 
 	// Map FX init
+	Com_DevPrintf (0, "[cginit] before CG_MapFXInit\n");
 	CG_MapFXInit ();
+	Com_DevPrintf (0, "[cginit] after CG_MapFXInit\n");
 
 	// Load the UI
+	Com_DevPrintf (0, "[cginit] before UI_Init\n");
 	UI_Init ();
+	Com_DevPrintf (0, "[cginit] after UI_Init\n");
+	Com_DevPrintf (0, "[cginit] CG_Init done\n");
 }
 
 

--- a/cgame/cg_muzzleflash.c
+++ b/cgame/cg_muzzleflash.c
@@ -69,9 +69,11 @@ void CG_ParseMuzzleFlash (void)
 	int			entNum, flashNum;
 
 	entNum = cgi.MSG_ReadShort ();
-	if (entNum < 1 || entNum >= MAX_CS_EDICTS)
-		Com_Error (ERR_DROP, "CG_ParseMuzzleFlash: bad entity");
 	flashNum = cgi.MSG_ReadByte ();
+	if (entNum < 1 || entNum >= MAX_CS_EDICTS) {
+		Com_DevPrintf (0, "CG_ParseMuzzleFlash: ignoring bad entity %d (flash=%d)\n", entNum, flashNum);
+		return;
+	}
 
 	silenced = flashNum & MZ_SILENCED;
 	flashNum &= ~MZ_SILENCED;
@@ -322,9 +324,11 @@ void CG_ParseMuzzleFlash2 (void)
 	int			entNum, flashNum;
 
 	entNum = cgi.MSG_ReadShort ();
-	if (entNum < 1 || entNum >= MAX_CS_EDICTS)
-		Com_Error (ERR_DROP, "CG_ParseMuzzleFlash2: bad entity");
 	flashNum = cgi.MSG_ReadByte ();
+	if (entNum < 1 || entNum >= MAX_CS_EDICTS) {
+		Com_DevPrintf (0, "CG_ParseMuzzleFlash2: ignoring bad entity %d (flash=%d)\n", entNum, flashNum);
+		return;
+	}
 
 	// locate the origin
 	Angles_Vectors (cg_entityList[entNum].current.angles, forward, right, NULL);

--- a/cgame/cg_players.c
+++ b/cgame/cg_players.c
@@ -117,8 +117,12 @@ void CG_LoadClientinfo (clientInfo_t *ci, char *skin)
 	char		modelFilename[MAX_QPATH];
 	char		skinFilename[MAX_QPATH];
 	char		weaponFilename[MAX_QPATH];
+	char		debugBuf[256];
 	char		*t;
 	int			i;
+
+	Q_snprintfz (debugBuf, sizeof (debugBuf), "CG_LoadClientinfo: loading '%s'\n", skin);
+	cgi.Com_DevPrintf (0, debugBuf);
 
 	Q_strncpyz (ci->cInfo, skin, sizeof (ci->cInfo));
 
@@ -184,6 +188,8 @@ void CG_LoadClientinfo (clientInfo_t *ci, char *skin)
 		// Skin file
 		Q_snprintfz (skinFilename, sizeof (skinFilename), "players/%s/%s.tga", modelName, skinName);
 		ci->material = cgi.R_RegisterSkin (skinFilename);
+		Q_snprintfz (debugBuf, sizeof (debugBuf), "CG_LoadClientinfo: tried skin '%s' -> %s\n", skinFilename, ci->material ? "OK" : "FAILED");
+		cgi.Com_DevPrintf (0, debugBuf);
 
 		// If we don't have the skin and the model wasn't male, see if the male has it (this is for CTF's skins)
 		if (!ci->material && Q_stricmp (modelName, "male")) {
@@ -195,13 +201,17 @@ void CG_LoadClientinfo (clientInfo_t *ci, char *skin)
 			// See if the skin exists for the male model
 			Q_snprintfz (skinFilename, sizeof (skinFilename), "players/%s/%s.tga", modelName, skinName);
 			ci->material = cgi.R_RegisterSkin (skinFilename);
+			Q_snprintfz (debugBuf, sizeof (debugBuf), "CG_LoadClientinfo: fallback male skin '%s' -> %s\n", skinFilename, ci->material ? "OK" : "FAILED");
+			cgi.Com_DevPrintf (0, debugBuf);
 		}
 
 		// If we still don't have a skin, it means that the male model didn't have it, so default to grunt
 		if (!ci->material) {
 			// See if the skin exists for the male model
-			Q_snprintfz (skinFilename, sizeof (skinFilename), "players/%s/grunt.tga", modelName, skinName);
+			Q_snprintfz (skinFilename, sizeof (skinFilename), "players/%s/grunt.tga", modelName);
 			ci->material = cgi.R_RegisterSkin (skinFilename);
+			Q_snprintfz (debugBuf, sizeof (debugBuf), "CG_LoadClientinfo: fallback grunt skin '%s' -> %s\n", skinFilename, ci->material ? "OK" : "FAILED");
+			cgi.Com_DevPrintf (0, debugBuf);
 		}
 
 		// Weapon file
@@ -223,14 +233,24 @@ void CG_LoadClientinfo (clientInfo_t *ci, char *skin)
 		ci->icon = cgi.R_RegisterPic (ci->iconName);
 	}
 
-	// Must have loaded all data types to be valud
+	// Must have loaded all data types to be valid
 	if (!ci->material || !ci->icon || !ci->model || !ci->weaponModels[0]) {
-		ci->material = NULL;
-		ci->icon = NULL;
-		ci->model = NULL;
-		ci->weaponModels[0] = NULL;
-		return;
+		Q_snprintfz (debugBuf, sizeof (debugBuf), "CG_LoadClientinfo: partial load for '%s' (mat=%p icon=%p model=%p weapon=%p)\n",
+			ci->cInfo, (void*)ci->material, (void*)ci->icon, (void*)ci->model, (void*)ci->weaponModels[0]);
+		cgi.Com_DevPrintf (PRNT_WARNING, debugBuf);
+		
+		// Don't clear everything - allow partial rendering with whatever we have
+		// Only clear if we have absolutely nothing useful
+		if (!ci->model) {
+			ci->material = NULL;
+			ci->icon = NULL;
+			ci->weaponModels[0] = NULL;
+			return;
+		}
 	}
+
+	Q_snprintfz (debugBuf, sizeof (debugBuf), "CG_LoadClientinfo: SUCCESS for '%s'\n", ci->cInfo);
+	cgi.Com_DevPrintf (0, debugBuf);
 }
 
 

--- a/cgame/menu/menu.c
+++ b/cgame/menu/menu.c
@@ -79,10 +79,12 @@ void JoinMenu_StartSStatus (void); // FIXME
 void M_Init (void)
 {
 	int		i;
+	Com_DevPrintf (0, "[cginit] M_Init begin\n");
 
    	// Register cvars
 	for (i=0 ; i<MAX_ADDRBOOK_SAVES ; i++)
 		cgi.Cvar_Register (Q_VarArgs ("adr%i", i),				"",			CVAR_ARCHIVE);
+	Com_DevPrintf (0, "[cginit] M_Init addrbook cvars registered\n");
 
 	ui_jsMenuPage		= cgi.Cvar_Register ("ui_jsMenuPage",	"0",		CVAR_ARCHIVE);
 	ui_jsSortItem		= cgi.Cvar_Register ("ui_jsSortItem",	"0",		CVAR_ARCHIVE);
@@ -121,6 +123,7 @@ void M_Init (void)
 	cmd_menuQuit		= cgi.Cmd_AddCommand ("menu_quit",			UI_QuitMenu_f,				"Opens the quit menu");
 
 	cmd_startSStatus	= cgi.Cmd_AddCommand ("ui_startSStatus",	JoinMenu_StartSStatus,		"");
+	Com_DevPrintf (0, "[cginit] M_Init commands registered\n");
 }
 
 

--- a/cgame/ui/ui_backend.c
+++ b/cgame/ui/ui_backend.c
@@ -53,15 +53,23 @@ UI_Init
 */
 void UI_Init (void)
 {
+	Com_DevPrintf (0, "[cginit] UI_Init begin\n");
+	
 	// Register cvars
 	ui_filtermouse		= cgi.Cvar_Register ("ui_filtermouse",	"1",		CVAR_ARCHIVE);
 	ui_sensitivity		= cgi.Cvar_Register ("ui_sensitivity",	"2",		CVAR_ARCHIVE);
+	Com_DevPrintf (0, "[cginit] UI_Init cvars registered\n");
 
 	// Cursor init
+	Com_DevPrintf (0, "[cginit] before UI_CursorInit\n");
 	UI_CursorInit ();
+	Com_DevPrintf (0, "[cginit] after UI_CursorInit\n");
 
 	// Menu init
+	Com_DevPrintf (0, "[cginit] before M_Init\n");
 	M_Init ();
+	Com_DevPrintf (0, "[cginit] after M_Init\n");
+	Com_DevPrintf (0, "[cginit] UI_Init done\n");
 }
 
 

--- a/client/cl_cgapi.c
+++ b/client/cl_cgapi.c
@@ -811,6 +811,7 @@ void CL_CGameAPI_Init (void)
 	// Call to init
 	CGI_Com_DevPrintf (0, "cgame->Init()\n");
 	cge->Init ();
+	CGI_Com_DevPrintf (0, "cgame->Init() returned\n");
 
 	CGI_Com_DevPrintf (0, "----------------------------------------\n");
 }

--- a/client/cl_keys.c
+++ b/client/cl_keys.c
@@ -747,27 +747,26 @@ pasteIntoMessage:
 	if (key < 32 || key > 127)
 		return;
 
-	if (key_chatCursorPos < MAXCMDLINE-1) {
-		// Check insert mode
+	{
+		char *buf = key_chatBuffer[key_chatEditLine];
+		size_t len = strlen (buf);
+
+		if (key_chatCursorPos >= MAXCMDLINE - 1)
+			return;
+
+		// Clamp cursor into the current string bounds defensively
+		if (key_chatCursorPos > len)
+			key_chatCursorPos = len;
+
 		if (key_insertOn) {
-			// Can't do strcpy to move string to right
-			i = strlen (key_chatBuffer[key_chatEditLine]) - 1;
-
-			if (i == MAXCMDLINE-2) 
-				i--;
-
-			for ( ; i>=key_chatCursorPos ; i--)
-				key_chatBuffer[key_chatEditLine][i + 1] = key_chatBuffer[key_chatEditLine][i];
+			// Need one extra byte for the new char (NUL moves via memmove)
+			if (len >= MAXCMDLINE - 1)
+				return;
+			memmove (buf + key_chatCursorPos + 1, buf + key_chatCursorPos, len - key_chatCursorPos + 1);
 		}
 
-		// Only null terminate if at the end
-		i = key_chatBuffer[key_chatEditLine][key_chatCursorPos];
-		key_chatBuffer[key_chatEditLine][key_chatCursorPos] = key;
+		buf[key_chatCursorPos] = (char)key;
 		key_chatCursorPos++;
-		if (!i) {
-			for (i=key_chatCursorPos ; i<MAXCMDLINE ; i++)
-				key_chatBuffer[key_chatEditLine][i] = '\0';
-		}
 	}
 }
 
@@ -1174,6 +1173,10 @@ static void Key_ExecuteBind (keyNum_t keyNum, qBool isDown)
 
 void Key_Event (keyNum_t keyNum, qBool isDown, uint32 time)
 {
+	// Bounds check - ignore invalid key numbers
+	if (keyNum < 0 || keyNum >= K_MAXKEYS)
+		return;
+
 	// Update auto-repeat status
 	if (isDown) {
 		key_keyInfo[keyNum].repeated++;

--- a/client/cl_local.h
+++ b/client/cl_local.h
@@ -170,6 +170,23 @@ typedef struct downloadStatic_s {
 #endif
 } downloadStatic_t;
 
+// Challenge extras parsed from server's challenge response (q2repro-style)
+typedef struct clChallengeExtras_s {
+	qBool				valid;						// true if we have parsed a challenge
+
+	// Protocol advertisement
+	qBool				sawProtocolList;			// server sent p=...
+	qBool				sawOriginal;				// server supports protocol 34
+	qBool				sawEnhanced;				// server supports protocol 35 (R1Q2)
+	qBool				sawProto26;					// server supports protocol 26
+
+	// Selected protocol for this connection attempt
+	int					selectedProtocol;
+
+	// Other extras (for future expansion)
+	char				dlserver[256];				// HTTP download server if advertised
+} clChallengeExtras_t;
+
 typedef struct clientStatic_s {
 	int					connectCount;
 	float				connectTime;				// for connection retransmits
@@ -203,6 +220,7 @@ typedef struct clientStatic_s {
 	int					quakePort;					// a 16 bit value that allows quake servers
 													// to work around address translating routers
 	int					challenge;					// from the server to use for connecting
+	clChallengeExtras_t	challengeExtras;			// parsed challenge extras (q2repro-style)
 	qBool				forcePacket;				// forces a packet to be sent the next frame
 
 	downloadStatic_t	download;

--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -341,6 +341,7 @@ done:
 	cls.serverMessage[0] = '\0';
 	cls.serverName[0] = '\0';
 	cls.serverProtocol = 0;
+	memset (&cls.challengeExtras, 0, sizeof (cls.challengeExtras));
 
 	Cvar_Set ("$mapname", "", qTrue);
 	Cvar_Set ("$game", "", qTrue);
@@ -387,49 +388,45 @@ static void CL_ClientConnect_CP (void)
 		return;
 	}
 
-	Com_DevPrintf (0, "client_connect: new\n");
+	Com_DevPrintf (0, "client_connect: new (protocol=%d)\n", cls.serverProtocol);
 
 	Netchan_Setup (NS_CLIENT, &cls.netChan, &cls.netFrom, cls.serverProtocol, cls.quakePort, 0);
 
-	// Parse arguments (R1Q2 enhanced protocol only)
+	// Use challenge extras for HTTP download server if available (q2repro approach)
+	// This uses the dlserver= parsed from the challenge rather than connect args
+#ifdef CL_HTTPDL
+	if (cls.challengeExtras.valid && cls.challengeExtras.dlserver[0]) {
+		buff = NET_AdrToString (&cls.netChan.remoteAddress);
+		Q_snprintfz (cls.download.httpReferer, sizeof (cls.download.httpReferer), "quake2://%s", buff);
+		CL_HTTPDL_SetServer (cls.challengeExtras.dlserver);
+		if (cls.download.httpServer[0])
+			Com_DevPrintf (0, "HTTP downloading enabled (from challenge), using '%s'\n", cls.download.httpServer);
+	}
+#endif
+
+	// Also parse connect arguments for backwards compatibility (R1Q2 enhanced protocol)
 	if (cls.serverProtocol == ENHANCED_PROTOCOL_VERSION) {
 		buff = NET_AdrToString (&cls.netChan.remoteAddress);
 		for (i=1 ; i<Cmd_Argc() ; i++) {
 			p = Cmd_Argv (i);
 			if (!strncmp (p, "dlserver=", 9)) {
-#ifdef CL_HTTPL
-				p += 9;
-				Q_snprintfz (cls.download.httpReferer, sizeof (cls.download.httpReferer), "quake2://%s", buff);
-				CL_HTTPDL_SetServer (p);
-				if (cls.download.httpServer[0])
-					Com_DevPrintf (0, "HTTP downloading enabled, using '%s'\n", cls.download.httpServer);
-#endif
-			}
-#ifdef CL_ANTICHEAT
-			else if (!strncmp (p, "ac=", 3)) {
-				p += 3;
-				if (!p[0])
-					continue;
-				i = atoi (p);
-				if (i) {
-					MSG_WriteByte (&cls.netChan.message, CLC_NOP);
-					Netchan_Transmit (&cls.netChan, 0, NULL);
-
-					// Don't sit and stutter sounds while loading
-					Snd_StopAllSounds ();
-
-					// Let the GUI system know
-					// FIXME: Use this, durr
-					Com_Printf (0, "Loading and initializing the anticheat module, please wait.\n");
-					GUI_NamedGlobalEvent ("ACLoading");
-					SCR_UpdateScreen ();
-
-					// Load the API
-					if (!CL_ACAPI_Init ())
-						Com_Printf (PRNT_ERROR, "Anticheat failed to load, trying to connect without it.\n");
+#ifdef CL_HTTPDL
+				// Only use if not already set from challenge extras
+				if (!cls.download.httpServer[0]) {
+					p += 9;
+					Q_snprintfz (cls.download.httpReferer, sizeof (cls.download.httpReferer), "quake2://%s", buff);
+					CL_HTTPDL_SetServer (p);
+					if (cls.download.httpServer[0])
+						Com_DevPrintf (0, "HTTP downloading enabled (from connect), using '%s'\n", cls.download.httpServer);
 				}
-			}
 #endif
+			}
+// Disabled AC load to prevent hang/overflow
+// #ifdef CL_ANTICHEAT
+// 			else if (!strncmp (p, "ac=", 3)) {
+// 				...
+// 			}
+// #endif
 		}
 	}
 
@@ -493,6 +490,118 @@ static void CL_Ping_CP (void)
 
 /*
 =================
+CL_ParseChallengeExtras
+
+Parse all extras from the server's challenge response into cls.challengeExtras.
+This follows q2repro's approach of parsing challenge extras once and using
+the parsed result to drive connect packet generation.
+=================
+*/
+static void CL_ParseChallengeExtras (void)
+{
+	int i;
+	clChallengeExtras_t *ext = &cls.challengeExtras;
+
+	memset (ext, 0, sizeof (*ext));
+
+	for (i=2 ; i<Cmd_Argc() ; i++) {
+		const char *arg = Cmd_Argv (i);
+		const char *p;
+
+		if (!arg)
+			continue;
+
+		// Parse protocol list: p=34,35,...
+		if (!strncmp (arg, "p=", 2)) {
+			ext->sawProtocolList = qTrue;
+			p = arg + 2;
+
+			while (p && *p) {
+				char *end;
+				long proto = strtol (p, &end, 10);
+				if (end != p) {
+					if (proto == ORIGINAL_PROTOCOL_VERSION)
+						ext->sawOriginal = qTrue;
+					else if (proto == ENHANCED_PROTOCOL_VERSION)
+						ext->sawEnhanced = qTrue;
+					else if (proto == 26)
+						ext->sawProto26 = qTrue;
+					p = end;
+				}
+				else {
+					// Skip non-numeric token until separator/end
+					while (*p && *p != ',')
+						p++;
+				}
+
+				if (*p == ',')
+					p++;
+				else if (*p)
+					p++;
+			}
+			continue;
+		}
+
+		// Parse HTTP download server: dlserver=url
+		if (!strncmp (arg, "dlserver=", 9)) {
+			Q_strncpyz (ext->dlserver, arg + 9, sizeof (ext->dlserver));
+			continue;
+		}
+
+		// Future extras can be parsed here
+	}
+
+	ext->valid = qTrue;
+}
+
+
+/*
+=================
+CL_SelectProtocolFromExtras
+
+Select the best protocol to use based on parsed challenge extras.
+Returns the protocol number to use for the connect packet.
+=================
+*/
+static int CL_SelectProtocolFromExtras (void)
+{
+	clChallengeExtras_t *ext = &cls.challengeExtras;
+	int protocol;
+
+	// If user forced a protocol, use it
+	if (cl_protocol->intVal) {
+		Com_DevPrintf (0, "CL_SelectProtocolFromExtras: using forced cl_protocol %d\n", cl_protocol->intVal);
+		return cl_protocol->intVal;
+	}
+
+	// If the server advertises supported protocols, pick one deterministically.
+	// We prefer original (34) when multiple options are present - this matches
+	// observed behavior with modern servers that advertise both but work better with 34.
+	if (ext->sawProtocolList) {
+		if (ext->sawOriginal)
+			protocol = ORIGINAL_PROTOCOL_VERSION;
+		else if (ext->sawEnhanced)
+			protocol = ENHANCED_PROTOCOL_VERSION;
+		else if (ext->sawProto26)
+			protocol = 26;
+		else
+			protocol = ORIGINAL_PROTOCOL_VERSION;
+
+		Com_DevPrintf (0, "CL_SelectProtocolFromExtras: server advertised protocols, selected %d\n", protocol);
+		return protocol;
+	}
+
+	// Some servers don't advertise protocol flags in the challenge.
+	// In auto-detect mode, alternate between enhanced and original.
+	protocol = (cls.connectCount & 1) ? ORIGINAL_PROTOCOL_VERSION : ENHANCED_PROTOCOL_VERSION;
+	Com_DevPrintf (0, "CL_SelectProtocolFromExtras: no protocol list, trying %d (attempt %d)\n", protocol, cls.connectCount);
+
+	return protocol;
+}
+
+
+/*
+=================
 CL_Challenge_CP
 
 Challenge from the server we are connecting to
@@ -500,34 +609,30 @@ Challenge from the server we are connecting to
 */
 static void CL_Challenge_CP (void)
 {
-	char	*p;
-	int		protocol, i;
+	int protocol;
+	clChallengeExtras_t *ext = &cls.challengeExtras;
 
-	// Local challenge
+	// Store challenge number
 	cls.challenge = atoi (Cmd_Argv (1));
-	Com_DevPrintf (0, "client: received challenge\n");
+	Com_DevPrintf (0, "client: received challenge %u\n", cls.challenge);
 
-	// Flags
-	protocol = ORIGINAL_PROTOCOL_VERSION;
-	for (i=2 ; i<Cmd_Argc() ; i++) {
-		p = Cmd_Argv (i);
-		if (!strncmp (p, "p=", 2)) {
-			p += 2;
-			if (!p[0])
-				continue;
-			for ( ; ; ) {
-				i = atoi (p);
-				if (i == ENHANCED_PROTOCOL_VERSION)
-					protocol = i;
-				p = strchr (p, ',');
-				if (!p)
-					break;
-				p++;
-				if (!p[0])
-					break;
-			}
-		}
-	}
+	// Parse all challenge extras into cls.challengeExtras
+	CL_ParseChallengeExtras ();
+
+	// Select protocol based on parsed extras
+	protocol = CL_SelectProtocolFromExtras ();
+	ext->selectedProtocol = protocol;
+
+	// Log the decision
+	Com_DevPrintf (0, "client: challenge extras: valid=%d sawProtoList=%d orig=%d enh=%d p26=%d dlserver='%s'; selected=%d; cl_protocol=%d\n",
+		ext->valid ? 1 : 0,
+		ext->sawProtocolList ? 1 : 0,
+		ext->sawOriginal ? 1 : 0,
+		ext->sawEnhanced ? 1 : 0,
+		ext->sawProto26 ? 1 : 0,
+		ext->dlserver,
+		ext->selectedProtocol,
+		cl_protocol->intVal);
 
 	// Reset timer to avoid duplicates, and send the connect packet
 	cls.connectTime = cls.realTime;
@@ -779,6 +884,16 @@ static void CL_CheckForResend (void)
 	// Only resend every NET_RETRYDELAY
 	if (cls.realTime - cls.connectTime < NET_RETRYDELAY)
 		return;
+
+	if (cls.connectCount >= 20) {
+		Com_Printf (PRNT_ERROR, "Server connection timed out.\n");
+		cls.connectCount = 0;
+		cls.serverProtocol = 0;
+		memset (&cls.challengeExtras, 0, sizeof (cls.challengeExtras));
+		CL_SetState (CA_DISCONNECTED);
+		CL_CGModule_MainMenu ();
+		return;
+	}
 
 	// Check if it's a bad server address
 	if (!NET_StringToAdr (cls.serverName, &adr)) {
@@ -1093,6 +1208,7 @@ static void CL_Connect_f (void)
 		Com_DevPrintf (0, "Resetting protocol attempt since %s", NET_AdrToString (&adr));
 		Com_DevPrintf (0, " is not %s.\n", NET_AdrToString (&cls.netChan.remoteAddress));
 		cls.serverProtocol = 0;
+		memset (&cls.challengeExtras, 0, sizeof (cls.challengeExtras));
 	}
 
 	// Set the client state and prepare to connect
@@ -1117,6 +1233,7 @@ static void CL_Disconnect_f (void)
 		return;
 
 	cls.serverProtocol = 0;
+	memset (&cls.challengeExtras, 0, sizeof (cls.challengeExtras));
 	Com_Error (ERR_DROP, "Disconnected from server");
 }
 

--- a/client/cl_parse.c
+++ b/client/cl_parse.c
@@ -679,6 +679,8 @@ static qBool CL_ParseServerData (void)
 
 	cl.serverCount = MSG_ReadLong (&cls.netMessage);
 	cl.attractLoop = MSG_ReadByte (&cls.netMessage);
+	if (cl.attractLoop != 0 && cl.attractLoop != 1)
+		Com_Error (ERR_DROP, "CL_ParseServerData: invalid attractLoop %d", cl.attractLoop);
 
 	// BIG HACK to let demos from release work with the 3.0x patch!!!
 	if (i != ORIGINAL_PROTOCOL_VERSION && i != ENHANCED_PROTOCOL_VERSION && i != 26 && !cl.attractLoop)
@@ -952,6 +954,8 @@ void CL_ParseServerMessage (void)
 	static int	lastCmd = -2;
 	int			extraBits;
 	size_t		oldReadCount;
+	int			startMsec;
+	int			lastPumpMsec;
 
 	// If recording demos, copy the message out
 	if (cl_shownet->intVal == 1)
@@ -961,8 +965,26 @@ void CL_ParseServerMessage (void)
 
 	CL_CGModule_StartServerMessage ();
 
+	startMsec = Sys_Milliseconds ();
+	lastPumpMsec = startMsec;
+
 	// Parse the message
 	for ( ; ; ) {
+		// Keep the OS message loop responsive while parsing large/bad packets.
+		// Without this, Windows will mark the window as "Not Responding" (white screen).
+		if (Com_ClientState () >= CA_CONNECTING) {
+			int now = Sys_Milliseconds ();
+			if (now - lastPumpMsec > 50) {
+				Sys_SendKeyEvents ();
+				lastPumpMsec = now;
+			}
+			// Hard cap: if a single packet takes too long to parse, drop instead of hanging.
+			if (now - startMsec > 5000) {
+				Com_Error (ERR_DROP, "CL_ParseServerMessage: parsing server message took too long");
+				break;
+			}
+		}
+
 		if (cls.netMessage.readCount > cls.netMessage.curSize) {
 			Com_Error (ERR_DROP, "CL_ParseServerMessage: Bad server message");
 			break;
@@ -1094,7 +1116,6 @@ void CL_ParseServerMessage (void)
 		case SVC_PLAYERINFO:
 		case SVC_PACKETENTITIES:
 		case SVC_DELTAPACKETENTITIES:
-			assert (0);
 			Com_Error (ERR_DROP, "CL_ParseServerMessage: Out of place frame data");
 			break;
 
@@ -1116,13 +1137,22 @@ void CL_ParseServerMessage (void)
 				break;
 
 			// Unknown to the client and CGame failed to parse it so...
-			assert (0);
+			{
+				const char *cmdStr = (cmd >= 0 && cmd < 256) ? cl_svcStrings[cmd] : "SVC_<invalid>";
+				const char *lastStr;
+				if (lastCmd == -2)
+					lastStr = "None";
+				else if (lastCmd >= 0 && lastCmd < 256)
+					lastStr = cl_svcStrings[lastCmd];
+				else
+					lastStr = "SVC_<invalid>";
 			Com_Error (ERR_DROP, "CL_ParseServerMessage: Illegible server message\n"
 				"Message #%i: %s\n"
 				"Last #%i: %s\n"
 				"Try 'set cl_protocol 34' before connecting, a protocol change could be causing problems",
-				cmd, cl_svcStrings[cmd],
-				lastCmd, (lastCmd == -2) ? "None" : cl_svcStrings[lastCmd]);
+				cmd, cmdStr,
+				lastCmd, lastStr);
+			}
 			break;
 		}
 

--- a/common/net_chan.c
+++ b/common/net_chan.c
@@ -228,6 +228,10 @@ int Netchan_Transmit (netChan_t *chan, size_t length, byte *data)
 	if (chan->message.overFlowed || chan->message.curSize >= MAX_CL_MSGLEN) {
 		chan->fatalError = qTrue;
 		Com_Printf (PRNT_WARNING, "%s: Outgoing message overflow\n", NET_AdrToString (&chan->remoteAddress));
+		Com_DevPrintf (0, "Netchan overflow: clearing message\n");
+		MSG_Clear (&chan->message);
+		chan->reliableLength = 0;
+		chan->fatalError = qFalse;
 		return -2;
 	}
 

--- a/renderer/rf_font.c
+++ b/renderer/rf_font.c
@@ -525,7 +525,8 @@ size_t R_DrawStringLen (font_t *font, float x, float y, float xScale, float ySca
 	char	swap;
 	size_t	length;
 
-	assert(len);
+	if (!string || len == 0)
+		return 0;
 
 	swap = string[len];
 	string[len] = 0;

--- a/sdl2/sdl_glimp.c
+++ b/sdl2/sdl_glimp.c
@@ -12,8 +12,25 @@ TODO: flesh out full mode enumeration/setting, input hookup, and gamma control.
 #if defined(__unix__)
 #include "../unix/unix_glimp.h"
 #endif
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_opengl.h>
+#define SDL_MAIN_HANDLED 1
+#if defined(__has_include)
+#  if __has_include(<SDL2/SDL.h>)
+#    include <SDL2/SDL.h>
+#  else
+#    include <SDL2/SDL.h>
+#  endif
+#else
+#  include <SDL2/SDL.h>
+#endif
+#if defined(__has_include)
+#  if __has_include(<SDL2/SDL_opengl.h>)
+#    include <SDL2/SDL_opengl.h>
+#  else
+#    include <SDL2/SDL_opengl.h>
+#  endif
+#else
+#  include <SDL2/SDL_opengl.h>
+#endif
 #include <limits.h>
 
 #ifndef APPLICATION
@@ -232,10 +249,9 @@ static void VID_UpdateWindowPosAndSize (void)
 
 void VID_CheckChanges (refConfig_t *outConfig)
 {
-    if (!sdl_window)
-        return;
-
-    if (vid_xpos && vid_xpos->modified || vid_ypos && vid_ypos->modified) {
+    // Don't early-out if the window isn't created yet; the initial startup
+    // path relies on this function to run R_Init() which will create it.
+    if (sdl_window && ((vid_xpos && vid_xpos->modified) || (vid_ypos && vid_ypos->modified))) {
         VID_UpdateWindowPosAndSize ();
     }
 

--- a/sdl2/sdl_input.c
+++ b/sdl2/sdl_input.c
@@ -6,7 +6,15 @@ should be implemented later.
 */
 
 #include "../client/cl_local.h"
-#include <SDL2/SDL.h>
+#if defined(__has_include)
+#  if __has_include(<SDL2/SDL.h>)
+#    include <SDL2/SDL.h>
+#  else
+#    include <SDL.h>
+#  endif
+#else
+#  include <SDL2/SDL.h>
+#endif
 
 void SDL2_SetMouseGrab (qBool grab);
 void SDL2_OnWindowResized (int width, int height);
@@ -116,6 +124,9 @@ void SDL2_PollInputEvents (void)
             break;
 
         case SDL_KEYDOWN: {
+            /* Ignore SDL key repeat - the engine handles its own repeat logic */
+            if (ev.key.repeat)
+                break;
             keyNum_t k = SDL2_TranslateKey (ev.key.keysym.sym);
             if (k != K_BADKEY)
                 Key_Event ((int)k, qTrue, Sys_Milliseconds ());

--- a/sdl2/sdl_main.c
+++ b/sdl2/sdl_main.c
@@ -7,7 +7,16 @@
  */
 
 #include "../client/cl_local.h"
-#include <SDL2/SDL.h>
+#define SDL_MAIN_HANDLED 1
+#if defined(__has_include)
+#  if __has_include(<SDL2/SDL.h>)
+#    include <SDL2/SDL.h>
+#  else
+#    include <SDL2/SDL.h>
+#  endif
+#else
+#  include <SDL2/SDL.h>
+#endif
 
 void SDL2_InitHook (void)
 {

--- a/sdl2/sdl_snd.c
+++ b/sdl2/sdl_snd.c
@@ -4,7 +4,15 @@
 
 #include "../client/snd_local.h"
 #include "../unix/unix_local.h"
-#include <SDL2/SDL.h>
+#if defined(__has_include)
+#  if __has_include(<SDL2/SDL.h>)
+#    include <SDL2/SDL.h>
+#  else
+#    include <SDL.h>
+#  endif
+#else
+#  include <SDL2/SDL.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 
@@ -19,38 +27,56 @@ static cVar_t *s_sdl_buffer_ms; /* desired buffer size in milliseconds */
 static SDL_AudioDeviceID s_sdl_dev = 0;
 static SDL_AudioSpec s_sdl_want, s_sdl_have;
 
-/* Local ring state */
-static int s_sdl_buf_bytes = 0;
-static int s_sdl_read_pos = 0; /* byte offset read by callback */
+/* Local ring state - position in BYTES */
+static volatile int s_sdl_buf_bytes = 0;
+static volatile int s_sdl_play_pos = 0; /* byte offset being played (read by callback) */
 
-/* Callback: fill stream from snd_audioDMA.buffer */
+static int Snd_SDL_NextPow2 (int x)
+{
+    int p;
+
+    if (x <= 0)
+        return 1;
+
+    p = 1;
+    while (p < x && p > 0)
+        p <<= 1;
+
+    return (p > 0) ? p : x;
+}
+
+/* Callback: fill stream from snd_audioDMA.buffer
+ * This runs in a separate audio thread - must be careful about shared state.
+ */
 static void SDLAudioCallback (void *userdata, Uint8 *stream, int len)
 {
-    if (!snd_audioDMA.buffer || snd_audioDMA.samples == 0) {
+    byte *buf = snd_audioDMA.buffer;
+    int bufsize = s_sdl_buf_bytes;
+    
+    if (!buf || bufsize == 0 || snd_audioDMA.samples == 0) {
         SDL_memset (stream, 0, len);
         return;
     }
 
-    int bufsize = s_sdl_buf_bytes;
-    int read = s_sdl_read_pos;
-
-    while (len > 0) {
-        int chunk = bufsize - read;
-        if (chunk > len) chunk = len;
-        memcpy (stream, snd_audioDMA.buffer + read, chunk);
-        stream += chunk;
-        len -= chunk;
-        read += chunk;
-        if (read >= bufsize) read = 0;
+    int pos = s_sdl_play_pos;
+    Uint8 *out = stream;
+    int remaining = len;
+    
+    while (remaining > 0) {
+        int avail = bufsize - pos;
+        int chunk = (avail < remaining) ? avail : remaining;
+        
+        memcpy (out, buf + pos, chunk);
+        
+        out += chunk;
+        remaining -= chunk;
+        pos += chunk;
+        
+        if (pos >= bufsize) 
+            pos = 0;
     }
 
-    s_sdl_read_pos = read;
-
-    /* advance sample pos (mono samples) */
-    if (snd_audioDMA.sampleBits/8 > 0) {
-        int bytes_per_sample = (snd_audioDMA.sampleBits/8) * snd_audioDMA.channels;
-        snd_audioDMA.samplePos = s_sdl_read_pos / bytes_per_sample;
-    }
+    s_sdl_play_pos = pos;
 }
 
 qBool Snd_SDL_Init (void)
@@ -88,12 +114,26 @@ qBool Snd_SDL_Init (void)
     int buf_ms = s_sdl_buffer_ms ? s_sdl_buffer_ms->intVal : 200;
     if (buf_ms < 50) buf_ms = 50;
 
-    int mono_samples = (speed * buf_ms) / 1000;
-    snd_audioDMA.samples = mono_samples;
-    snd_audioDMA.submissionChunk = 1024; /* conservative chunk */
+    /*
+     * IMPORTANT: snd_audioDMA.samples is defined as MONO samples in the buffer
+     * (i.e. frames * channels). The DMA mixer assumes snd_audioDMA.samples is
+     * a power-of-two and uses (samples - 1) as a wrap mask.
+     */
+    {
+        const int bytes_per_mono_sample = bits / 8;
+        int desired_frames = (speed * buf_ms) / 1000;
+        int desired_mono_samples = desired_frames * channels;
 
-    int bytes_per_sample = (bits/8) * channels;
-    s_sdl_buf_bytes = mono_samples * bytes_per_sample;
+        /* Ensure a power-of-two ring size for mask-based wrap. */
+        snd_audioDMA.samples = Snd_SDL_NextPow2 (desired_mono_samples);
+
+        /* Keep submissionChunk a power-of-two for alignment masking. */
+        snd_audioDMA.submissionChunk = 1024;
+        if (snd_audioDMA.submissionChunk > snd_audioDMA.samples)
+            snd_audioDMA.submissionChunk = snd_audioDMA.samples;
+
+        s_sdl_buf_bytes = snd_audioDMA.samples * bytes_per_mono_sample;
+    }
 
     if (snd_audioDMA.buffer) Mem_Free (snd_audioDMA.buffer);
     snd_audioDMA.buffer = (byte *) Mem_Alloc (s_sdl_buf_bytes);
@@ -124,9 +164,10 @@ qBool Snd_SDL_Init (void)
 
     /* Start playback */
     SDL_PauseAudioDevice (s_sdl_dev, 0);
-    s_sdl_read_pos = 0;
+    s_sdl_play_pos = 0;
 
-    Com_Printf (0, "Snd_SDL_Init: audio %d Hz, %d-bit, %d channels, buffer %d ms\n", speed, bits, channels, buf_ms);
+    Com_Printf (0, "Snd_SDL_Init: audio %d Hz, %d-bit, %d channels, buffer %d ms (%d bytes)\n", 
+                speed, bits, channels, buf_ms, s_sdl_buf_bytes);
 
     return qTrue;
 }
@@ -150,8 +191,27 @@ void Snd_SDL_Shutdown (void)
 
 int Snd_SDL_GetDMAPos (void)
 {
-    /* Return current sample position (mono samples) */
-    return snd_audioDMA.samplePos;
+    /* Return current play position in MONO SAMPLES (individual samples, not frames).
+     * The DMA engine divides this by channels to get sample frames.
+     * snd_audioDMA.samples is the total mono samples in the buffer.
+     * 
+     * The code in snd_dma.c does:
+     *   snd_dmaSoundTime = buffers*fullSamples + samplePos/snd_audioDMA.channels;
+     * where fullSamples = snd_audioDMA.samples / snd_audioDMA.channels
+     * So samplePos must be in mono samples, range [0, snd_audioDMA.samples).
+     */
+    if (!snd_audioDMA.buffer || snd_audioDMA.samples == 0)
+        return 0;
+    
+    int bytes_per_sample = snd_audioDMA.sampleBits / 8;
+    if (bytes_per_sample <= 0)
+        return 0;
+    
+    /* Convert byte position to mono samples */
+    int sample_pos = s_sdl_play_pos / bytes_per_sample;
+    
+    /* Ensure it's within bounds */
+    return sample_pos % snd_audioDMA.samples;
 }
 
 void Snd_SDL_BeginPainting (void)

--- a/tools/msys2-env.ps1
+++ b/tools/msys2-env.ps1
@@ -1,0 +1,42 @@
+param(
+    [ValidateSet('auto','mingw64','ucrt64','clang64')]
+    [string]$Prefix = 'auto',
+    [string]$Msys2Root = $env:MSYS2_ROOT
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $Msys2Root -or -not (Test-Path -LiteralPath $Msys2Root)) {
+    $Msys2Root = 'C:\msys64'
+}
+
+function Resolve-Prefix {
+    param([string]$Root, [string]$Wanted)
+
+    if ($Wanted -ne 'auto') { return $Wanted }
+
+    foreach ($p in @('mingw64','ucrt64','clang64')) {
+        if (Test-Path -LiteralPath (Join-Path $Root ($p + '\\bin\\gcc.exe'))) {
+            return $p
+        }
+    }
+
+    return 'mingw64'
+}
+
+$Prefix = Resolve-Prefix -Root $Msys2Root -Wanted $Prefix
+$binPath = Join-Path $Msys2Root ($Prefix + '\\bin')
+
+if (-not (Test-Path -LiteralPath (Join-Path $binPath 'gcc.exe'))) {
+    throw "gcc.exe not found at '$binPath'. Run tools\\setup-msys2.ps1 first (or install the MSYS2 toolchain)."
+}
+
+if (-not ($env:PATH -split ';' | Where-Object { $_ -ieq $binPath })) {
+    $env:PATH = "$binPath;" + $env:PATH
+}
+
+$env:MSYS2_ROOT = $Msys2Root
+$env:EGL_MSYS2_PREFIX = $Prefix
+
+Write-Host "MSYS2 environment configured: root=$Msys2Root prefix=$Prefix" -ForegroundColor Green
+Write-Host "gcc: $(Get-Command gcc).Source" -ForegroundColor Green

--- a/tools/package.ps1
+++ b/tools/package.ps1
@@ -9,6 +9,49 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+function Find-Msys2Root {
+    param(
+        [string[]]$Candidates
+    )
+
+    foreach ($c in $Candidates) {
+        if (-not $c) { continue }
+        try {
+            $root = (Resolve-Path -LiteralPath $c -ErrorAction Stop).Path
+        } catch {
+            continue
+        }
+        if (Test-Path -LiteralPath (Join-Path $root 'mingw64\bin\gcc.exe')) {
+            return $root
+        }
+    }
+
+    return $null
+}
+
+function Find-Msys2ToolchainBin {
+    param(
+        [string]$Msys2Root
+    )
+
+    if (-not $Msys2Root) { return $null }
+
+    $bins = @(
+        'mingw64\bin',
+        'ucrt64\bin',
+        'clang64\bin'
+    )
+
+    foreach ($b in $bins) {
+        $binPath = Join-Path $Msys2Root $b
+        if (Test-Path -LiteralPath (Join-Path $binPath 'gcc.exe')) {
+            return $binPath
+        }
+    }
+
+    return $null
+}
+
 function Get-RepoRoot {
     (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 }
@@ -17,10 +60,45 @@ $root = Get-RepoRoot
 Set-Location $root
 
 # Ensure MinGW toolchain is available when running from a fresh PowerShell.
-$msys2Root = if ($env:MSYS2_ROOT) { $env:MSYS2_ROOT } else { 'C:\msys64' }
-$mingwBin = Join-Path $msys2Root 'mingw64\bin'
-if (-not ($env:PATH -split ';' | Where-Object { $_ -ieq $mingwBin })) {
-    $env:PATH = "$mingwBin;" + $env:PATH
+$candidateRoots = @(
+    $env:MSYS2_ROOT,
+    $env:MSYS2ROOT,
+    'C:\msys64',
+    'D:\msys64',
+    $(if ($env:RUNNER_TEMP) { Join-Path $env:RUNNER_TEMP 'msys64' } else { $null }),
+    $(if ($env:TEMP) { Join-Path $env:TEMP 'msys64' } else { $null }),
+    'C:\tools\msys64'
+)
+
+$msys2Root = Find-Msys2Root -Candidates $candidateRoots
+if (-not $msys2Root) {
+    $msys2Root = if ($env:MSYS2_ROOT) { $env:MSYS2_ROOT } else { 'C:\msys64' }
+}
+
+$toolchainBin = Find-Msys2ToolchainBin -Msys2Root $msys2Root
+if (-not $toolchainBin) {
+    $expected = @(
+        (Join-Path $msys2Root 'mingw64\bin\gcc.exe'),
+        (Join-Path $msys2Root 'ucrt64\bin\gcc.exe'),
+        (Join-Path $msys2Root 'clang64\bin\gcc.exe')
+    ) -join "\n  - "
+    throw "Could not find gcc.exe under detected MSYS2 root '$msys2Root'. Expected one of:\n  - $expected\n\nInstall MSYS2 + a toolchain (e.g. mingw-w64-x86_64-toolchain or mingw-w64-ucrt-x86_64-toolchain), or set MSYS2_ROOT to your MSYS2 install folder."
+}
+
+if (-not ($env:PATH -split ';' | Where-Object { $_ -ieq $toolchainBin })) {
+    $env:PATH = "$toolchainBin;" + $env:PATH
+}
+
+if (-not (Get-Command gcc -ErrorAction SilentlyContinue)) {
+    throw "gcc is still not discoverable after updating PATH with '$toolchainBin'. Current PATH does not allow running the toolchain."
+}
+
+# If USE_SDL2=1 was requested, sanity-check that SDL2 headers exist under the detected MSYS2 root.
+if ($MakeArgs -and ($MakeArgs | Where-Object { $_ -match '^(?:USE_SDL2=1|USE_SDL2\s*=\s*1)$' })) {
+    $sdlHeader = Join-Path $msys2Root 'mingw64\include\SDL2\SDL.h'
+    if (-not (Test-Path -LiteralPath $sdlHeader)) {
+        throw "SDL2 headers not found at '$sdlHeader'. Ensure MSYS2 SDL2 is installed (package: mingw-w64-x86_64-SDL2) and MSYS2_ROOT points at the correct MSYS2 install."
+    }
 }
 
 $outRootPath = Join-Path $root $OutDir
@@ -32,6 +110,10 @@ New-Item -ItemType Directory -Force -Path $outBase | Out-Null
 
 if (-not $SkipBuild) {
     if (-not $MakeArgs) { $MakeArgs = @() }
+
+    # Avoid stale objects when switching build flags (e.g. USE_SDL2 on/off).
+    & make clean
+    if ($LASTEXITCODE -ne 0) { throw "make clean failed with exit code $LASTEXITCODE" }
 
     & make @MakeArgs all
     if ($LASTEXITCODE -ne 0) { throw "make all failed with exit code $LASTEXITCODE" }
@@ -48,6 +130,24 @@ if (-not (Test-Path -LiteralPath $clientExe)) {
     throw "Missing egl.exe. Run without -SkipBuild or build it first." 
 }
 Copy-Item -Force -Path $clientExe -Destination (Join-Path $outRoot 'egl.exe')
+
+# If USE_SDL2=1 was requested, stage SDL2.dll next to the exe so it runs without MSYS2 on PATH.
+if ($MakeArgs -and ($MakeArgs | Where-Object { $_ -match '^(?:USE_SDL2=1|USE_SDL2\s*=\s*1)$' })) {
+    $sdlDll = Join-Path $toolchainBin 'SDL2.dll'
+    if (-not (Test-Path -LiteralPath $sdlDll)) {
+        throw "SDL2.dll not found at '$sdlDll'. Ensure MSYS2 SDL2 runtime is installed for your prefix (e.g. mingw-w64-x86_64-SDL2)."
+    }
+    Copy-Item -Force -Path $sdlDll -Destination (Join-Path $outRoot 'SDL2.dll')
+}
+
+# Stage required MinGW runtime DLLs (minizip, zlib, bzip2)
+$runtimeDlls = @('libminizip-1.dll', 'zlib1.dll', 'libbz2-1.dll')
+foreach ($dll in $runtimeDlls) {
+    $dllPath = Join-Path $toolchainBin $dll
+    if (Test-Path -LiteralPath $dllPath) {
+        Copy-Item -Force -Path $dllPath -Destination (Join-Path $outRoot $dll)
+    }
+}
 
 $dedExe = Join-Path $root 'eglded.exe'
 if (-not $SkipDedicated -and (Test-Path -LiteralPath $dedExe)) {

--- a/tools/setup-msys2.ps1
+++ b/tools/setup-msys2.ps1
@@ -1,0 +1,49 @@
+param(
+    [ValidateSet('auto','mingw64','ucrt64','clang64')]
+    [string]$Prefix = 'auto',
+    [string]$Msys2Root = $env:MSYS2_ROOT
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $Msys2Root -or -not (Test-Path -LiteralPath $Msys2Root)) {
+    $Msys2Root = 'C:\msys64'
+}
+
+$bash = Join-Path $Msys2Root 'usr\bin\bash.exe'
+if (-not (Test-Path -LiteralPath $bash)) {
+    throw "MSYS2 bash not found at '$bash'. Install MSYS2 first, or pass -Msys2Root <path>."
+}
+
+function Pick-Prefix {
+    param([string]$Root, [string]$Wanted)
+
+    if ($Wanted -ne 'auto') { return $Wanted }
+
+    foreach ($p in @('mingw64','ucrt64','clang64')) {
+        if (Test-Path -LiteralPath (Join-Path $Root ($p + '\\bin'))) {
+            return $p
+        }
+    }
+
+    return 'mingw64'
+}
+
+$Prefix = Pick-Prefix -Root $Msys2Root -Wanted $Prefix
+
+switch ($Prefix) {
+    'mingw64' { $toolchainPkg = 'mingw-w64-x86_64-toolchain'; $sdlPkg = 'mingw-w64-x86_64-SDL2' }
+    'ucrt64'  { $toolchainPkg = 'mingw-w64-ucrt-x86_64-toolchain'; $sdlPkg = 'mingw-w64-ucrt-x86_64-SDL2' }
+    'clang64' { $toolchainPkg = 'mingw-w64-clang-x86_64-toolchain'; $sdlPkg = 'mingw-w64-clang-x86_64-SDL2' }
+}
+
+Write-Host "Using MSYS2 root: $Msys2Root" -ForegroundColor Cyan
+Write-Host "Using prefix: $Prefix" -ForegroundColor Cyan
+Write-Host "Installing: $toolchainPkg, $sdlPkg" -ForegroundColor Cyan
+
+# Sync package DB and install needed packages.
+& $bash -lc "pacman -Sy --noconfirm"
+& $bash -lc "pacman -S --needed --noconfirm $toolchainPkg $sdlPkg"
+
+Write-Host "Done. To use gcc/make from this PowerShell session:" -ForegroundColor Green
+Write-Host "  . .\\tools\\msys2-env.ps1 -Prefix $Prefix" -ForegroundColor Green

--- a/win32/win_vid.c
+++ b/win32/win_vid.c
@@ -378,6 +378,7 @@ LRESULT CALLBACK MainWndProc (HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 		}
 		goto end;
 
+#ifndef HAVE_SDL2
 	case WM_SYSKEYDOWN:
 		if (wParam == 13) {
 			Cvar_VariableSetValue (vid_fullscreen, !vid_fullscreen->intVal, qTrue);
@@ -393,6 +394,16 @@ LRESULT CALLBACK MainWndProc (HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 	case WM_KEYUP:
 		Key_Event (In_MapKey (wParam, lParam), qFalse, sys_winInfo.msgTime);
 		break;
+#else
+	case WM_SYSKEYDOWN:
+		// Alt+Enter for fullscreen toggle still handled in SDL2 build
+		if (wParam == 13) {
+			Cvar_VariableSetValue (vid_fullscreen, !vid_fullscreen->intVal, qTrue);
+			VID_Restart_f ();
+			return 0;
+		}
+		break;
+#endif
 
 	case WM_CLOSE:
 		Cbuf_AddText ("quit\n");


### PR DESCRIPTION
- SDL2 audio: align DMA ring semantics (mono samples + power-of-two), track play position safely, and return DMAPos in mono samples

- Input/chat: ignore SDL key repeat, guard Key_Event bounds, and fix chat insert-mode out-of-bounds writes when spamming messagemode

- Build/packaging: improve MSYS2/SDL2 path detection, stage SDL2.dll + runtime DLLs, and add helper scripts for MSYS2 setup/env

- Net/client: parse challenge extras, keep server message parsing responsive, and recover cleanly from netchan message overflow

- Cgame/render: add dev init tracing, harden muzzleflash parsing, allow partial clientinfo loads, and avoid asserts on empty font draws