### PR TITLE
Fix SDL2 vid_restart input; implement gl_coloredlightmaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ A backup of EGL 0.3.1, as it was, from QuakeSrc back in 2007.
 The short-term focus is keeping builds working on Linux + Windows (MSYS2/MinGW64), especially via the SDL2 backend.
 Expect the build system and platform backends to continue evolving.
 
+## Notes (renderer + platform fixes)
+
+- `gl_coloredlightmaps`: older EGL builds could have this cvar set via configs, but it was not actually implemented in the renderer. This repo now implements it for Quake II BSP lightmaps.
+- SDL2 + `vid_restart`: the SDL2 backend now restores mouse grab/relative mode and hides the OS cursor after a restart.
+
 ## Running
 EGL is an engine; it expects Quake II base game data to be present.
 

--- a/renderer/r_local.h
+++ b/renderer/r_local.h
@@ -826,6 +826,7 @@ extern cVar_t	*r_ext_maxAnisotropy;
 extern cVar_t	*gl_finish;
 extern cVar_t	*gl_flashblend;
 extern cVar_t	*gl_lightmap;
+extern cVar_t	*gl_coloredlightmaps;
 extern cVar_t	*gl_lockpvs;
 extern cVar_t	*gl_log;
 extern cVar_t	*gl_maxTexSize;

--- a/renderer/rf_image.c
+++ b/renderer/rf_image.c
@@ -216,13 +216,17 @@ void GL_ResetAnisotropy (void)
 	uint32	i;
 	image_t	*image;
 	int		set;
+	int		maxAniso;
 
 	r_ext_maxAnisotropy->modified = qFalse;
 	if (!ri.config.extTexFilterAniso)
 		return;
 
 	// Change all the existing mipmap texture objects
-	set = clamp (r_ext_maxAnisotropy->intVal, 1, ri.config.maxAniso);
+	maxAniso = ri.config.maxAniso;
+	if (maxAniso < 1)
+		maxAniso = 1;
+	set = clamp (r_ext_maxAnisotropy->intVal, 1, maxAniso);
 	for (i=0, image=r_imageList ; i<r_numImages ; i++, image++) {
 		if (!image->touchFrame)
 			continue;	// Free r_imageList slot
@@ -1332,7 +1336,7 @@ static void R_UploadCMImage (char *name, byte **data, int width, int height, tex
 			qglTexParameteri (GL_TEXTURE_CUBE_MAP_ARB, GL_GENERATE_MIPMAP_SGIS, GL_TRUE);
 
 		if (ri.config.extTexFilterAniso)
-			qglTexParameteri (GL_TEXTURE_CUBE_MAP_ARB, GL_TEXTURE_MAX_ANISOTROPY_EXT, clamp (r_ext_maxAnisotropy->intVal, 1, ri.config.maxAniso));
+			qglTexParameteri (GL_TEXTURE_CUBE_MAP_ARB, GL_TEXTURE_MAX_ANISOTROPY_EXT, clamp (r_ext_maxAnisotropy->intVal, 1, (ri.config.maxAniso < 1) ? 1 : ri.config.maxAniso));
 
 		qglTexParameteri (GL_TEXTURE_CUBE_MAP_ARB, GL_TEXTURE_MIN_FILTER, ri.texMinFilter);
 		qglTexParameteri (GL_TEXTURE_CUBE_MAP_ARB, GL_TEXTURE_MAG_FILTER, ri.texMagFilter);
@@ -1494,7 +1498,7 @@ static void R_Upload2DImage (char *name, byte *data, int width, int height, texF
 			qglTexParameteri (GL_TEXTURE_2D, GL_GENERATE_MIPMAP_SGIS, GL_TRUE);
 
 		if (ri.config.extTexFilterAniso)
-			qglTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, clamp (r_ext_maxAnisotropy->intVal, 1, ri.config.maxAniso));
+			qglTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, clamp (r_ext_maxAnisotropy->intVal, 1, (ri.config.maxAniso < 1) ? 1 : ri.config.maxAniso));
 
 		qglTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, ri.texMinFilter);
 		qglTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, ri.texMagFilter);
@@ -1658,7 +1662,7 @@ static void R_Upload3DImage (char *name, byte **data, int width, int height, int
 			qglTexParameteri (GL_TEXTURE_3D, GL_GENERATE_MIPMAP_SGIS, GL_TRUE);
 
 		if (ri.config.extTexFilterAniso)
-			qglTexParameteri (GL_TEXTURE_3D, GL_TEXTURE_MAX_ANISOTROPY_EXT, clamp (r_ext_maxAnisotropy->intVal, 1, ri.config.maxAniso));
+			qglTexParameteri (GL_TEXTURE_3D, GL_TEXTURE_MAX_ANISOTROPY_EXT, clamp (r_ext_maxAnisotropy->intVal, 1, (ri.config.maxAniso < 1) ? 1 : ri.config.maxAniso));
 
 		qglTexParameteri (GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, ri.texMinFilter);
 		qglTexParameteri (GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, ri.texMagFilter);

--- a/renderer/rf_init.c
+++ b/renderer/rf_init.c
@@ -59,6 +59,7 @@ cVar_t	*r_ext_vertexProgram;
 cVar_t	*gl_finish;
 cVar_t	*gl_flashblend;
 cVar_t	*gl_lightmap;
+cVar_t	*gl_coloredlightmaps;
 cVar_t	*gl_lockpvs;
 cVar_t	*gl_log;
 cVar_t	*gl_maxTexSize;
@@ -1202,6 +1203,7 @@ static void R_Register (void)
 	gl_finish			= Cvar_Register ("gl_finish",			"0",			CVAR_ARCHIVE);
 	gl_flashblend		= Cvar_Register ("gl_flashblend",		"0",			CVAR_ARCHIVE);
 	gl_lightmap			= Cvar_Register ("gl_lightmap",			"0",			CVAR_CHEAT);
+	gl_coloredlightmaps	= Cvar_Register ("gl_coloredlightmaps",	"1",			CVAR_ARCHIVE);
 	gl_lockpvs			= Cvar_Register ("gl_lockpvs",			"0",			CVAR_CHEAT);
 	gl_log				= Cvar_Register ("gl_log",				"0",			0);
 	gl_maxTexSize		= Cvar_Register ("gl_maxTexSize",		"0",			CVAR_ARCHIVE|CVAR_LATCH_VIDEO);

--- a/renderer/rf_light.c
+++ b/renderer/rf_light.c
@@ -93,6 +93,10 @@ void R_Q2BSP_MarkWorldLights (void)
 	if (gl_flashblend->intVal)
 		return;
 
+	// gl_dynamic 2: keep switchable lightmap updates, but disable dlights.
+	if (gl_dynamic->intVal != 1)
+		return;
+
 	for (lt=ri.scn.dLightList, i=0 ; i<ri.scn.numDLights ; i++, lt++)
 		R_Q2BSP_r_MarkWorldLights (ri.scn.worldModel->bspModel.nodes, lt, 1<<i);
 }
@@ -150,7 +154,8 @@ void R_Q2BSP_MarkBModelLights (refEntity_t *ent, vec3_t mins, vec3_t maxs)
 	mBspNode_t		*node;
 	uint32			i;
 
-	if (!ri.scn.numDLights || gl_flashblend->intVal || !gl_dynamic->intVal || r_fullbright->intVal)
+	// gl_dynamic 2: keep switchable lightmap updates, but disable dlights.
+	if (!ri.scn.numDLights || gl_flashblend->intVal || gl_dynamic->intVal != 1 || r_fullbright->intVal)
 		return;
 
 	node = ent->model->bspModel.nodes + ent->model->q2BspModel.firstNode;
@@ -421,7 +426,7 @@ fullBright:
 	//
 	// Add dynamic lights
 	//
-	if (gl_dynamic->intVal && ri.scn.numDLights) {
+	if (gl_dynamic->intVal == 1 && ri.scn.numDLights) {
 		refDLight_t	*lt;
 		float		dist, add, intensity8, intensity;
 		vec3_t		dlOrigin;
@@ -507,12 +512,14 @@ static void R_Q2BSP_LightPoint (vec3_t point, vec3_t light)
 	//
 	// Add dynamic lights
 	//
-	for (lt=ri.scn.dLightList, num=0 ; num<ri.scn.numDLights ; num++, lt++) {
-		Vec3Subtract (point, lt->origin, dist);
-		add = (lt->intensity - Vec3Length (dist)) * (1.0f/256.0f);
+	if (gl_dynamic->intVal == 1 && ri.scn.numDLights) {
+		for (lt=ri.scn.dLightList, num=0 ; num<ri.scn.numDLights ; num++, lt++) {
+			Vec3Subtract (point, lt->origin, dist);
+			add = (lt->intensity - Vec3Length (dist)) * (1.0f/256.0f);
 
-		if (add > 0)
-			Vec3MA (light, add, lt->color, light);
+			if (add > 0)
+				Vec3MA (light, add, lt->color, light);
+		}
 	}
 }
 
@@ -658,6 +665,7 @@ static void R_Q2BSP_BuildLightMap (mBspSurface_t *surf, byte *dest, int stride)
 	float		*bl, max;
 	vec3_t		scale;
 	byte		*lightMap;
+	float		colorAmount;
 
 	if (surf->q2_texInfo->flags & (SURF_TEXINFO_SKY|SURF_TEXINFO_WARP))
 		Com_Error (ERR_DROP, "LM_BuildLightMap called for non-lit surface");
@@ -746,14 +754,17 @@ static void R_Q2BSP_BuildLightMap (mBspSurface_t *surf, byte *dest, int stride)
 			}
 		}
 
-		// Add all the dynamic lights
-		if (surf->dLightFrame == ri.frameCount)
+		// Add all the dynamic lights (gl_dynamic 1 only)
+		if (gl_dynamic->intVal == 1 && surf->dLightFrame == ri.frameCount)
 			R_Q2BSP_AddDynamicLights (surf);
 	}
 
 	// Put into texture format
 	stride -= (surf->q2_lmWidth << 2);
 	bl = surf->q2_blockLights;
+	colorAmount = 1.0f;
+	if (gl_coloredlightmaps)
+		colorAmount = clamp (gl_coloredlightmaps->floatVal, 0.0f, 1.0f);
 
 	for (i=0 ; i<surf->q2_lmHeight ; i++) {
 		for (j=0 ; j<surf->q2_lmWidth ; j++) {
@@ -765,28 +776,24 @@ static void R_Q2BSP_BuildLightMap (mBspSurface_t *surf, byte *dest, int stride)
 			if (bl[2] < 0)
 				bl[2] = 0;
 
-			// Determine the brightest of the three color components
-			max = bl[0];
-			if (bl[1] > max)
-				max = bl[1];
-			if (bl[2] > max)
-				max = bl[2];
-
-			// Normalize the color components to the highest channel
-			if (max > 255) {
-				max = 255.0f / max;
-
-				dest[0] = (byte)(bl[0]*max);
-				dest[1] = (byte)(bl[1]*max);
-				dest[2] = (byte)(bl[2]*max);
-				dest[3] = (byte)(255*max);
+			// Optional grayscale: lerp between grayscale intensity and colored light
+			if (colorAmount < 1.0f) {
+				float intensity = (bl[0] + bl[1] + bl[2]) * (1.0f / 3.0f);
+				bl[0] = intensity + (bl[0] - intensity) * colorAmount;
+				bl[1] = intensity + (bl[1] - intensity) * colorAmount;
+				bl[2] = intensity + (bl[2] - intensity) * colorAmount;
 			}
-			else {
-				dest[0] = (byte)bl[0];
-				dest[1] = (byte)bl[1];
-				dest[2] = (byte)bl[2];
-				dest[3] = 255;
-			}
+
+			// Clamp to 8-bit. This makes gl_modulate > 1 actually brighten the world
+			// (the previous "normalize into alpha" path wasn't used by the renderer).
+			if (bl[0] > 255) bl[0] = 255;
+			if (bl[1] > 255) bl[1] = 255;
+			if (bl[2] > 255) bl[2] = 255;
+
+			dest[0] = (byte)bl[0];
+			dest[1] = (byte)bl[1];
+			dest[2] = (byte)bl[2];
+			dest[3] = 255;
 
 			bl += 3;
 			dest += 4;
@@ -833,14 +840,20 @@ void R_Q2BSP_UpdateLightmap (mBspSurface_t *surf)
 	}
 
 	// Dynamic this frame or dynamic previously
+	// gl_dynamic:
+	// 0 - no updates (switchable lights won't animate)
+	// 1 - allow style updates + dlights
+	// 2 - allow style updates only (switchable lights), but disable dlights
 	if (gl_dynamic->intVal) {
 		for (map=0 ; map<surf->q2_numStyles ; map++) {
 			if (ri.scn.lightStyles[surf->q2_styles[map]].white != surf->q2_cachedLight[map])
 				goto dynamic;
 		}
 
-		if (surf->dLightFrame == ri.frameCount)
+		if (gl_dynamic->intVal == 1 && surf->dLightFrame == ri.frameCount) {
+			map = 0;
 			goto dynamic;
+		}
 	}
 
 	// No need to update

--- a/sdl2/sdl_glimp.c
+++ b/sdl2/sdl_glimp.c
@@ -59,6 +59,9 @@ void SDL2_SetMouseGrab (qBool grab)
     if (!sdl_window)
         return;
 
+    // Keep OS cursor from reappearing when the window is re-created (e.g. vid_restart)
+    // and relative mode is temporarily lost.
+    SDL_ShowCursor (grab ? SDL_DISABLE : SDL_ENABLE);
     SDL_SetRelativeMouseMode (grab ? SDL_TRUE : SDL_FALSE);
     SDL_SetWindowGrab (sdl_window, grab ? SDL_TRUE : SDL_FALSE);
 }
@@ -283,6 +286,9 @@ void VID_CheckChanges (refConfig_t *outConfig)
 
         Snd_Init ();
         CL_MediaInit ();
+
+        // Restart input after a vid_restart so we reapply SDL relative mouse mode/grab.
+        IN_Restart_f ();
 
         cls.disableScreen = qFalse;
 

--- a/sdl2/sdl_input.c
+++ b/sdl2/sdl_input.c
@@ -23,6 +23,8 @@ void GLimp_AppActivate (qBool active);
 static qBool sdl_appActive = qTrue;
 static qBool sdl_mouseGrabbed = qFalse;
 
+static void *cmd_in_restart = NULL;
+
 static void SDL2_SetGrabState (qBool grab)
 {
     if (sdl_mouseGrabbed == grab)
@@ -232,11 +234,19 @@ void IN_Init (void)
 {
     sdl_appActive = qTrue;
     SDL2_SetGrabState (qFalse);
+
+    if (!cmd_in_restart)
+        cmd_in_restart = Cmd_AddCommand ("in_restart", IN_Restart_f, "Restarts input subsystem");
 }
 
 void IN_Shutdown (void)
 {
     SDL2_SetGrabState (qFalse);
+
+    if (cmd_in_restart) {
+        Cmd_RemoveCommand ("in_restart", cmd_in_restart);
+        cmd_in_restart = NULL;
+    }
 }
 
 void IN_Activate (qBool active)
@@ -244,6 +254,21 @@ void IN_Activate (qBool active)
     // Force a new grab check in IN_Frame.
     if (!active)
         SDL2_SetGrabState (qFalse);
+}
+
+/*
+=================
+IN_Restart_f
+
+Needed after vid_restart: SDL window recreation can reset relative mouse mode.
+=================
+*/
+void IN_Restart_f (void)
+{
+    // Force a grab state re-apply.
+    sdl_mouseGrabbed = qFalse;
+    SDL2_SetGrabState (qFalse);
+    IN_Frame ();
 }
 
 /*


### PR DESCRIPTION
gl_coloredlightmaps existed in configs but wasn’t implemented in older EGL, now fixed
SDL2 vid_restart now restores mouse grab/relative mode + hides cursor