### PR TITLE
feat: Add R1Q2 (protocol 35) and Q2Pro (protocol 36) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,16 @@ Thumbs.db
 # Local runtime-generated files
 /eglcfg.cfg
 /console.log
+
+# Protocol debugging / test captures
+*.pcapng
+
+# Test build output directories
+/out_runcheck*/
+
+# Downloaded archives / reference implementations
+*.zip
+anticheat.txt
+
+# Python analysis tools (local dev)
+/tools/analyze_packet.py

--- a/client/cl_download.c
+++ b/client/cl_download.c
@@ -141,7 +141,9 @@ qBool CL_CheckOrDownloadFile (char *fileName)
 		Com_Printf (0, "Resuming %s\n", cls.download.name);
 
 		MSG_WriteByte (&cls.netChan.message, CLC_STRINGCMD);
-		if (cls.serverProtocol == ENHANCED_PROTOCOL_VERSION)
+		// R1Q2 (35) always supports zlib, Q2Pro (36) supports zlib when minor >= 1021
+		if (cls.serverProtocol == ENHANCED_PROTOCOL_VERSION ||
+			(cls.serverProtocol == Q2PRO_PROTOCOL_VERSION && cls.protocolMinorVersion >= MINOR_VERSION_Q2PRO_ZLIB_DOWNLOADS))
 			MSG_WriteString (&cls.netChan.message, Q_VarArgs ("download \"%s\" %i udp-zlib", cls.download.name, len));
 		else
 			MSG_WriteString (&cls.netChan.message, Q_VarArgs ("download \"%s\" %i", cls.download.name, len));
@@ -150,7 +152,9 @@ qBool CL_CheckOrDownloadFile (char *fileName)
 		Com_Printf (0, "Downloading %s\n", cls.download.name);
 
 		MSG_WriteByte (&cls.netChan.message, CLC_STRINGCMD);
-		if (cls.serverProtocol == ENHANCED_PROTOCOL_VERSION)
+		// R1Q2 (35) always supports zlib, Q2Pro (36) supports zlib when minor >= 1021
+		if (cls.serverProtocol == ENHANCED_PROTOCOL_VERSION ||
+			(cls.serverProtocol == Q2PRO_PROTOCOL_VERSION && cls.protocolMinorVersion >= MINOR_VERSION_Q2PRO_ZLIB_DOWNLOADS))
 			MSG_WriteString (&cls.netChan.message, Q_VarArgs ("download \"%s\" 0 udp-zlib", cls.download.name));
 		else
 			MSG_WriteString (&cls.netChan.message, Q_VarArgs ("download \"%s\"", cls.download.name));
@@ -172,10 +176,21 @@ void CL_ParseDownload (qBool compressed)
 {
 	int		size, percent;
 	char	name[MAX_OSPATH];
+	qBool	inbandZlib = qFalse;
 
 	// Read the data
 	size = MSG_ReadShort (&cls.netMessage);
 	percent = MSG_ReadByte (&cls.netMessage);
+
+	// R1Q2 (protocol 35) can send zlib-compressed download blocks using SVC_DOWNLOAD
+	// by encoding the compressed length as a negative size: size = -(compressedLen + 1).
+	// The payload format then matches SVC_ZDOWNLOAD: [short uncompressedLen] [compressed bytes].
+	if (!compressed && cls.serverProtocol == ENHANCED_PROTOCOL_VERSION && size < -1) {
+		inbandZlib = qTrue;
+		size = -size - 1;
+		compressed = qTrue;
+	}
+
 	if (size < 0) {
 		if (size == -1)
 			Com_Printf (PRNT_WARNING, "Server does not have this file.\n");
@@ -198,7 +213,12 @@ void CL_ParseDownload (qBool compressed)
 	// Open the file if not opened yet
 	if (!cls.download.file) {
 		if (!cls.download.tempName[0]) {
-			Com_Printf (PRNT_WARNING, "Received download packet without requesting it first, ignoring.\n");
+			Com_Printf (PRNT_WARNING, "Received download packet without requesting it first, ignoring (size=%d, percent=%d, compressed=%d).\n", size, percent, compressed);
+			// Skip payload bytes so we don't desync the server message parser.
+			if (compressed)
+				cls.netMessage.readCount += 2 + size; // [short uncompressedLen] + data
+			else
+				cls.netMessage.readCount += size;
 			return;
 		}
 
@@ -208,7 +228,11 @@ void CL_ParseDownload (qBool compressed)
 
 		cls.download.file = fopen (name, "wb");
 		if (!cls.download.file) {
-			cls.netMessage.readCount += size;
+			// Skip payload bytes so we don't desync the server message parser.
+			if (compressed)
+				cls.netMessage.readCount += 2 + size; // [short uncompressedLen] + data
+			else
+				cls.netMessage.readCount += size;
 			Com_Printf (PRNT_WARNING, "Failed to open %s\n", cls.download.tempName);
 			CL_RequestNextDownload ();
 			return;
@@ -217,6 +241,10 @@ void CL_ParseDownload (qBool compressed)
 
 	// Insert block
  	if (compressed) {
+		if (cls.serverProtocol == Q2PRO_PROTOCOL_VERSION) {
+			Com_Error (ERR_DROP, "CL_ParseDownload: Q2Pro compressed downloads (svc_zdownload) not supported yet");
+		}
+
  		uint16		uncompressedLen;
  		static byte	uncompressed[0xFFFF];
 
@@ -224,9 +252,9 @@ void CL_ParseDownload (qBool compressed)
  		if (!uncompressedLen)
 			Com_Error (ERR_DROP, "CL_ParseDownload: uncompressedLen == 0");
 
- 		FS_ZLibDecompress (cls.netMessage.data + cls.netMessage.readCount, size, uncompressed, uncompressedLen, -15);
+		FS_ZLibDecompress (cls.netMessage.data + cls.netMessage.readCount, size, uncompressed, uncompressedLen, -15);
  		fwrite (uncompressed, 1, uncompressedLen, cls.download.file);
- 		Com_DevPrintf (0, "SVC_ZDOWNLOAD(%s): %d -> %d\n", cls.download.name, size, uncompressedLen);
+		Com_DevPrintf (0, "%s(%s): %d -> %d\n", inbandZlib ? "SVC_DOWNLOAD_ZLIB" : "SVC_ZDOWNLOAD", cls.download.name, size, uncompressedLen);
  	}
  	else {
 		fwrite (cls.netMessage.data + cls.netMessage.readCount, 1, size, cls.download.file);

--- a/client/cl_local.h
+++ b/client/cl_local.h
@@ -178,6 +178,7 @@ typedef struct clChallengeExtras_s {
 	qBool				sawProtocolList;			// server sent p=...
 	qBool				sawOriginal;				// server supports protocol 34
 	qBool				sawEnhanced;				// server supports protocol 35 (R1Q2)
+	qBool				sawQ2Pro;					// server supports protocol 36 (Q2Pro)
 	qBool				sawProto26;					// server supports protocol 26
 
 	// Selected protocol for this connection attempt
@@ -211,6 +212,7 @@ typedef struct clientStatic_s {
 	char				serverNameLast[MAX_OSPATH];
 	int					serverProtocol;				// in case we are doing some kind of version hack
 	int					protocolMinorVersion;
+	uint32				negotiatedMsgLen;			// negotiated message length for enhanced protocols
 
 	netAdr_t			netFrom;
 	netMsg_t			netMessage;
@@ -221,6 +223,8 @@ typedef struct clientStatic_s {
 													// to work around address translating routers
 	int					challenge;					// from the server to use for connecting
 	clChallengeExtras_t	challengeExtras;			// parsed challenge extras (q2repro-style)
+	qBool				challengeQueryPending;		// true if we're waiting for a challenge reply for a query-only request
+	netAdr_t			challengeQueryAdr;			// server address for the outstanding query-only request
 	qBool				forcePacket;				// forces a packet to be sent the next frame
 
 	downloadStatic_t	download;
@@ -459,6 +463,10 @@ void		CL_ClearState (void);
 void		CL_Disconnect (qBool openMenu);
 
 void		CL_Frame (int msec);
+
+// Ensures userinfo contains version keys that satisfy servers enforcing
+// a minimum Quake II patch level (typically 3.19+).
+void			CL_ForceUserinfoVersion (char *userinfoStr);
 
 void		CL_ClientInit (void);
 void		CL_ClientShutdown (qBool error);

--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -100,6 +100,7 @@ qBool CL_ForwardCmdToServer (void)
 	char	*cmd;
 
 	cmd = Cmd_Argv (0);
+
 	if (Com_ClientState () <= CA_CONNECTED || *cmd == '-' || *cmd == '+')
 		return qFalse;
 
@@ -127,6 +128,8 @@ static void CL_SendConnectPacket (int useProtocol)
 	netAdr_t	adr;
 	int			port;
 	uint32		msgLen;
+	char		userInfoStr[MAX_INFO_STRING];
+	char		verStr[16];
 
 	if (!NET_StringToAdr (cls.serverName, &adr)) {
 		Com_Printf (PRNT_WARNING, "Bad server address\n");
@@ -164,11 +167,13 @@ static void CL_SendConnectPacket (int useProtocol)
 			}
 		}
 
-		// Enhanced protocol port is a byte
-		if (cls.serverProtocol == ENHANCED_PROTOCOL_VERSION) {
+		// Enhanced protocols (R1Q2/Q2Pro) use byte qport
+		if (cls.serverProtocol >= ENHANCED_PROTOCOL_VERSION) {
 			port &= 0xff;
 
 			msgLen = Cvar_GetIntegerValue ("net_maxMsgLen");
+			if (msgLen < MAX_SV_USABLEMSG)
+				msgLen = MAX_SV_USABLEMSG;  // Ensure minimum sensible value
 			if (msgLen > MAX_CL_USABLEMSG)
 				msgLen = MAX_CL_USABLEMSG;
 		}
@@ -179,14 +184,188 @@ static void CL_SendConnectPacket (int useProtocol)
 
 	cls.quakePort = port;
 
-	// Send
+	// Build userinfo and ensure version keys are present for servers that
+	// enforce a minimum Quake II patch level (typically 3.19+).
+	if (cls.serverProtocol == Q2PRO_PROTOCOL_VERSION) {
+		// Reconstruct userinfo manually for Q2Pro to avoid potential garbage from Cvar_BitInfo
+		// or unsupported keys that might trigger strict validation issues.
+		char skinStr[MAX_INFO_VALUE];
+		int i;
+		const char *v;
+
+		userInfoStr[0] = 0;
+		Info_SetValueForKey(userInfoStr, "name", Cvar_GetStringValue("name"));
+		
+		// Normalize legacy skin format for Q2Pro: "male/grunt" -> "male_grunt"
+		Q_strncpyz (skinStr, Cvar_GetStringValue("skin"), sizeof (skinStr));
+		for (i = 0; skinStr[i]; i++) {
+			if (skinStr[i] == '/')
+				skinStr[i] = '_';
+		}
+		Info_SetValueForKey(userInfoStr, "skin", skinStr);
+		
+		// ONLY add fields with non-zero/non-empty values for Q2Pro
+		if ((v = Cvar_GetStringValue("rate"))[0] && atoi(v) > 0)
+			Info_SetValueForKey(userInfoStr, "rate", v);
+		else
+			Info_SetValueForKey(userInfoStr, "rate", "8000");
+			
+		if ((v = Cvar_GetStringValue("msg"))[0] && atoi(v) > 0)
+			Info_SetValueForKey(userInfoStr, "msg", v);
+		else
+			Info_SetValueForKey(userInfoStr, "msg", "64");
+			
+		if ((v = Cvar_GetStringValue("fov"))[0] && atoi(v) > 0)
+			Info_SetValueForKey(userInfoStr, "fov", v);
+		
+		if ((v = Cvar_GetStringValue("hand"))[0] && strcmp(v, "0") != 0)
+			Info_SetValueForKey(userInfoStr, "hand", v);
+		else
+			Info_SetValueForKey(userInfoStr, "hand", "right");
+			
+		Info_SetValueForKey(userInfoStr, "gender", Cvar_GetStringValue("gender"));
+		Info_SetValueForKey(userInfoStr, "spectator", Cvar_GetStringValue("spectator"));
+	} else {
+		Q_strncpyz (userInfoStr, Cvar_BitInfo (CVAR_USERINFO), sizeof (userInfoStr));
+	}
+	
+	// Q2Pro strict validation: remove ALL fields with "0" value BEFORE forcing version
+	// Q2Pro's Info_Validate rejects any field with value "0" as malformed
+	if (cls.serverProtocol == Q2PRO_PROTOCOL_VERSION) {
+		char cleanInfo[MAX_INFO_STRING];
+		char tempKey[MAX_INFO_KEY];
+		char tempValue[MAX_INFO_VALUE];
+		const char *p;
+		int len;
+
+		cleanInfo[0] = 0;
+
+		// Parse through userinfo: format is \key\value\key\value...
+		p = userInfoStr;
+		while (*p == '\\') {
+			p++;  // skip leading backslash
+			
+			// Extract key
+			len = 0;
+			while (p[len] && p[len] != '\\' && len < (int)sizeof(tempKey) - 1) {
+				tempKey[len] = p[len];
+				len++;
+			}
+			tempKey[len] = 0;
+			p += len;
+
+			if (*p != '\\') break;  // malformed
+			p++;  // skip backslash before value
+
+			// Extract value
+			len = 0;
+			while (p[len] && p[len] != '\\' && len < (int)sizeof(tempValue) - 1) {
+				tempValue[len] = p[len];
+				len++;
+			}
+			tempValue[len] = 0;
+			p += len;
+
+			// Only add if value is not "0"
+			if (strcmp(tempValue, "0") != 0) {
+				Info_SetValueForKey(cleanInfo, tempKey, tempValue);
+			}
+		}
+
+		Q_strncpyz(userInfoStr, cleanInfo, sizeof(userInfoStr));
+	}
+	
+	CL_ForceUserinfoVersion (userInfoStr);
+
+	// Sanitize userinfo string to prevent "Malformed userinfo string" server error
+	// For Q2Pro/enhanced protocols, the format is already strict and validated.
+	// Only sanitize for older protocols.
+	if (cls.serverProtocol < ENHANCED_PROTOCOL_VERSION) {
+		int i;
+		for (i = 0; userInfoStr[i]; i++) {
+			if (userInfoStr[i] < 32 || userInfoStr[i] > 126) {
+				userInfoStr[i] = '.';
+			}
+			if (userInfoStr[i] == '\"' || userInfoStr[i] == ';') {
+				userInfoStr[i] = '.';
+			}
+		}
+	}
+
+	// Debug output
 	Com_DevPrintf (0, "CL_SendConnectPacket: protocol=%d, port=%d, challenge=%u\n", cls.serverProtocol, port, cls.challenge);
-	if (cls.serverProtocol == ENHANCED_PROTOCOL_VERSION)
-		Netchan_OutOfBandPrint (NS_CLIENT, &adr, "connect %i %i %i \"%s\" %u\n",
-			cls.serverProtocol, port, cls.challenge, Cvar_BitInfo (CVAR_USERINFO), msgLen);
-	else
-		Netchan_OutOfBandPrint (NS_CLIENT, &adr, "connect %i %i %i \"%s\"\n",
-			cls.serverProtocol, port, cls.challenge, Cvar_BitInfo (CVAR_USERINFO));
+
+	Q_strncpyz (verStr, Info_ValueForKey (userInfoStr, "ver"), sizeof (verStr));
+	Com_Printf (0, "CL_SendConnectPacket: sending protocol=%d ver=\"%s\" version=\"%s\" userinfo len=%zu\n",
+		cls.serverProtocol,
+		verStr[0] ? verStr : "(none)",
+		Info_ValueForKey (userInfoStr, "version"),
+		strlen (userInfoStr));
+	Com_Printf (0, "Full UserInfo: [%s]\n", userInfoStr);
+
+	// Send
+	// Protocol 35 (R1Q2) and 36 (Q2Pro) use extended connect formats.
+	// Quote the userinfo argument so spaces in values (e.g. name) remain intact.
+	// Important: do NOT append a '\n' here. Some strict servers include it in the
+	// parsed userinfo and reject it as non-printable.
+	
+	if (cls.serverProtocol >= ENHANCED_PROTOCOL_VERSION) {
+		if (cls.serverProtocol == Q2PRO_PROTOCOL_VERSION) {
+			// Q2Pro 36: send msgLen + flags
+			Com_Printf (0, "CL_SendConnectPacket: Q2PRO format with msgLen=%u\n", msgLen);
+			Netchan_OutOfBandPrint (NS_CLIENT, &adr, "connect %i %i %i \"%s\" %u 0 0 0",
+				cls.serverProtocol, port, cls.challenge, userInfoStr, msgLen);
+		}
+		else {
+			// R1Q2 35: format is "connect proto port challenge userinfo msglen version"
+			// The version (arg 6) tells the server which usercmd format we use.
+			// ENHANCED_COMPATIBILITY_NUMBER (1905) >= MINOR_VERSION_R1Q2_UCMD_UPDATES (1904)
+			// so the server will expect the optimized usercmd format.
+			Com_Printf (0, "CL_SendConnectPacket: R1Q2 format with msgLen=%u version=%d\n", msgLen, ENHANCED_COMPATIBILITY_NUMBER);
+			Netchan_OutOfBandPrint (NS_CLIENT, &adr, "connect %i %i %i \"%s\" %u %d",
+				cls.serverProtocol, port, cls.challenge, userInfoStr, msgLen, ENHANCED_COMPATIBILITY_NUMBER);
+		}
+		// Save negotiated msgLen for use in Netchan_Setup
+		cls.negotiatedMsgLen = msgLen;
+	}
+	else {
+		Com_Printf (0, "CL_SendConnectPacket: original format (no msgLen)\n");
+		Netchan_OutOfBandPrint (NS_CLIENT, &adr, "connect %i %i %i \"%s\"",
+			cls.serverProtocol, port, cls.challenge, userInfoStr);
+	}
+}
+
+
+/*
+=======================
+CL_ForceUserinfoVersion
+
+Some modded servers enforce a minimum Quake II patch level and parse the
+userinfo "version" key using atof/sscanf.
+
+To maximize compatibility, keep both "ver" and "version" as a plain
+numeric string and avoid adding non-standard keys.
+=======================
+*/
+void CL_ForceUserinfoVersion (char *userinfoStr)
+{
+	if (!userinfoStr)
+		return;
+
+	// Only spoof client identifiers for Q2Pro protocol 36.
+	// Doing this for protocol 35 (R1Q2) can make servers assume Q2Pro-specific
+	// features and send messages our protocol-35 parser doesn't expect.
+	if (cls.serverProtocol == Q2PRO_PROTOCOL_VERSION) {
+		const char *forcedClientStr = "Q2PROCL";
+		const char *forcedVersionStr = "Q2PROCL";
+
+		Info_SetValueForKey (userinfoStr, "client", forcedClientStr);
+		Info_SetValueForKey (userinfoStr, "version", forcedVersionStr);
+
+		// Remove conflicting keys
+		Info_RemoveKey (userinfoStr, "ver");
+		Info_RemoveKey (userinfoStr, "customclient");
+	}
 }
 
 
@@ -390,7 +569,7 @@ static void CL_ClientConnect_CP (void)
 
 	Com_DevPrintf (0, "client_connect: new (protocol=%d)\n", cls.serverProtocol);
 
-	Netchan_Setup (NS_CLIENT, &cls.netChan, &cls.netFrom, cls.serverProtocol, cls.quakePort, 0);
+	Netchan_Setup (NS_CLIENT, &cls.netChan, &cls.netFrom, cls.serverProtocol, cls.quakePort, cls.negotiatedMsgLen);
 
 	// Use challenge extras for HTTP download server if available (q2repro approach)
 	// This uses the dlserver= parsed from the challenge rather than connect args
@@ -524,6 +703,8 @@ static void CL_ParseChallengeExtras (void)
 						ext->sawOriginal = qTrue;
 					else if (proto == ENHANCED_PROTOCOL_VERSION)
 						ext->sawEnhanced = qTrue;
+					else if (proto == Q2PRO_PROTOCOL_VERSION)
+						ext->sawQ2Pro = qTrue;
 					else if (proto == 26)
 						ext->sawProto26 = qTrue;
 					p = end;
@@ -539,7 +720,6 @@ static void CL_ParseChallengeExtras (void)
 				else if (*p)
 					p++;
 			}
-			continue;
 		}
 
 		// Parse HTTP download server: dlserver=url
@@ -568,20 +748,52 @@ static int CL_SelectProtocolFromExtras (void)
 	clChallengeExtras_t *ext = &cls.challengeExtras;
 	int protocol;
 
-	// If user forced a protocol, use it
+	// If user forced a protocol, prefer it.
+	// If the server advertises a protocol list and the forced protocol isn't in it,
+	// fall back to an advertised protocol instead of forcing a mismatch.
 	if (cl_protocol->intVal) {
-		Com_DevPrintf (0, "CL_SelectProtocolFromExtras: using forced cl_protocol %d\n", cl_protocol->intVal);
-		return cl_protocol->intVal;
+		const int forced = cl_protocol->intVal;
+		if (ext->sawProtocolList) {
+			qBool supported = qFalse;
+
+			if (forced == ORIGINAL_PROTOCOL_VERSION && ext->sawOriginal)
+				supported = qTrue;
+			else if (forced == ENHANCED_PROTOCOL_VERSION && ext->sawEnhanced)
+				supported = qTrue;
+			else if (forced == Q2PRO_PROTOCOL_VERSION && ext->sawQ2Pro)
+				supported = qTrue;
+			else if (forced == 26 && ext->sawProto26)
+				supported = qTrue;
+
+			if (supported) {
+				Com_DevPrintf (0, "CL_SelectProtocolFromExtras: using forced cl_protocol %d (advertised)\n", forced);
+				return forced;
+			}
+
+			Com_Printf (PRNT_WARNING,
+				"WARNING: Server challenge did not advertise cl_protocol %d (p-list: orig=%d enh=%d p36=%d p26=%d). Falling back to advertised protocol.\n",
+				forced,
+				ext->sawOriginal ? 1 : 0,
+				ext->sawEnhanced ? 1 : 0,
+				ext->sawQ2Pro ? 1 : 0,
+				ext->sawProto26 ? 1 : 0);
+			// Continue below to advertised selection.
+		}
+		else {
+			Com_DevPrintf (0, "CL_SelectProtocolFromExtras: using forced cl_protocol %d (no p-list advertised)\n", forced);
+			return forced;
+		}
 	}
 
 	// If the server advertises supported protocols, pick one deterministically.
-	// We prefer original (34) when multiple options are present - this matches
-	// observed behavior with modern servers that advertise both but work better with 34.
+	// Prefer the most feature-complete protocol we understand.
 	if (ext->sawProtocolList) {
-		if (ext->sawOriginal)
-			protocol = ORIGINAL_PROTOCOL_VERSION;
+		if (ext->sawQ2Pro)
+			protocol = Q2PRO_PROTOCOL_VERSION;
 		else if (ext->sawEnhanced)
 			protocol = ENHANCED_PROTOCOL_VERSION;
+		else if (ext->sawOriginal)
+			protocol = ORIGINAL_PROTOCOL_VERSION;
 		else if (ext->sawProto26)
 			protocol = 26;
 		else
@@ -614,7 +826,7 @@ static void CL_Challenge_CP (void)
 
 	// Store challenge number
 	cls.challenge = atoi (Cmd_Argv (1));
-	Com_DevPrintf (0, "client: received challenge %u\n", cls.challenge);
+	Com_Printf (0, "CL_Challenge_CP: challenge=%u\n", cls.challenge);
 
 	// Parse all challenge extras into cls.challengeExtras
 	CL_ParseChallengeExtras ();
@@ -622,17 +834,31 @@ static void CL_Challenge_CP (void)
 	// Select protocol based on parsed extras
 	protocol = CL_SelectProtocolFromExtras ();
 	ext->selectedProtocol = protocol;
+	Com_Printf (0, "CL_Challenge_CP: selected protocol=%d\n", protocol);
 
 	// Log the decision
-	Com_DevPrintf (0, "client: challenge extras: valid=%d sawProtoList=%d orig=%d enh=%d p26=%d dlserver='%s'; selected=%d; cl_protocol=%d\n",
+	Com_DevPrintf (0, "client: challenge extras: valid=%d sawProtoList=%d orig=%d enh=%d p36=%d p26=%d dlserver='%s'; selected=%d; cl_protocol=%d\n",
 		ext->valid ? 1 : 0,
 		ext->sawProtocolList ? 1 : 0,
 		ext->sawOriginal ? 1 : 0,
 		ext->sawEnhanced ? 1 : 0,
+		ext->sawQ2Pro ? 1 : 0,
 		ext->sawProto26 ? 1 : 0,
 		ext->dlserver,
 		ext->selectedProtocol,
 		cl_protocol->intVal);
+
+	// If this was a query-only request, do not send a connect packet.
+	if (cls.challengeQueryPending) {
+		cls.challengeQueryPending = qFalse;
+		Com_Printf (0, "challengequery: done (selected=%d; advertised: orig=%d enh=%d p36=%d p26=%d)\n",
+			protocol,
+			ext->sawOriginal ? 1 : 0,
+			ext->sawEnhanced ? 1 : 0,
+			ext->sawQ2Pro ? 1 : 0,
+			ext->sawProto26 ? 1 : 0);
+		return;
+	}
 
 	// Reset timer to avoid duplicates, and send the connect packet
 	cls.connectTime = cls.realTime;
@@ -673,11 +899,32 @@ static void CL_ConnectionlessPacket (void)
 	Cmd_TokenizeString (cmd, qFalse);
 
 	cmd = Cmd_Argv (0);
+	
+	// Debug: show all incoming connectionless packets
+	Com_Printf (0, "CL_ConnectionlessPacket: received '%s' from %s\n", cmd, NET_AdrToString (&cls.netFrom));
 
+	// Diagnostic: during a query-only getchallenge (challengequery), always accept
+	// the challenge reply so we can see advertised protocol extras, even when not
+	// formally connected/allowed yet.
+	if (cls.challengeQueryPending && !strcmp (cmd, "challenge")) {
+		CL_Challenge_CP ();
+		return;
+	}
+
+	// Handle critical connection commands before address filtering
 	if (!strcmp (cmd, "client_connect")) {
 		Com_Printf (0, "%s: %s\n", NET_AdrToString (&cls.netFrom), cmd);
 		CL_ClientConnect_CP ();
 		return;
+	}
+	else if (!strcmp (cmd, "challenge")) {
+		// Handle challenge response early to avoid address filtering issues
+		// during the initial connection handshake
+		if (Com_ClientState () == CA_CONNECTING) {
+			Com_Printf (0, "%s: %s\n", NET_AdrToString (&cls.netFrom), cmd);
+			CL_Challenge_CP ();
+			return;
+		}
 	}
 	else if (!strcmp (cmd, "info")) {
 		CL_Info_CP ();
@@ -696,9 +943,16 @@ static void CL_ConnectionlessPacket (void)
 		isPrint = qFalse;
 	}
 
-	// Only allow the following from current connected server and last destination client sent an rcon to
+	// Only allow the following from current connected server and last destination client sent an rcon to.
+	// Also allow a one-off challenge response when a query-only getchallenge is in flight.
 	NET_StringToAdr (cls.serverName, &remote);
-	if (!NET_CompareBaseAdr (cls.netFrom, remote) && !NET_CompareBaseAdr (cls.netFrom, cl_lastRConTo)) {
+	Com_DevPrintf (0, "CL_ConnectionlessPacket: checking address - from=%s, serverName=%s, remote=%s\n",
+		NET_AdrToString (&cls.netFrom), cls.serverName, NET_AdrToString (&remote));
+	if (!(
+		(cls.challengeQueryPending && NET_CompareBaseAdr (cls.netFrom, cls.challengeQueryAdr))
+		|| NET_CompareBaseAdr (cls.netFrom, remote)
+		|| NET_CompareBaseAdr (cls.netFrom, cl_lastRConTo)
+	)) {
 		Com_Printf (PRNT_WARNING, "Illegal %s from %s. Ignored.\n", cmd, NET_AdrToString (&cls.netFrom));
 		return;
 	}
@@ -1202,6 +1456,7 @@ static void CL_Connect_f (void)
 
 	// Disconnect if connected
 	CL_Disconnect (qFalse);
+	cls.challengeQueryPending = qFalse;
 
 	// Reset the protocol attempt if we're connecting to a different server
 	if (!NET_CompareAdr (adr, cls.netChan.remoteAddress)) {
@@ -1360,6 +1615,48 @@ static void CL_PingServer_f (void)
 		adr.port = BigShort (PORT_SERVER);
 
 	Netchan_OutOfBandPrint (NS_CLIENT, &adr, Q_VarArgs ("info %i", ORIGINAL_PROTOCOL_VERSION));
+}
+
+
+/*
+================
+CL_ChallengeQuery_f
+
+Sends a getchallenge packet and prints the parsed challenge extras without attempting a full connect.
+Useful to confirm whether a server actually advertises protocol 35/36 support.
+================
+*/
+static void CL_ChallengeQuery_f (void)
+{
+	netAdr_t	adr;
+	char	*adrString;
+
+	if (Cmd_Argc () != 2) {
+		Com_Printf (0, "usage: challengequery <address>[:port]\n");
+		return;
+	}
+
+	NET_Config (NET_CLIENT);
+
+	adrString = Cmd_Argv (1);
+	if (!adrString || !adrString[0])
+		return;
+
+	if (!NET_StringToAdr (adrString, &adr)) {
+		Com_Printf (PRNT_WARNING, "Bad address: %s\n", adrString);
+		return;
+	}
+
+	if (!adr.port)
+		adr.port = BigShort (PORT_SERVER);
+
+	// Clear any previous parsed extras; mark a query-only request in flight.
+	memset (&cls.challengeExtras, 0, sizeof (cls.challengeExtras));
+	cls.challengeQueryPending = qTrue;
+	cls.challengeQueryAdr = adr;
+
+	Com_Printf (0, "challengequery: sending getchallenge to %s...\n", NET_AdrToString (&adr));
+	Netchan_OutOfBandPrint (NS_CLIENT, &adr, "getchallenge\n");
 }
 
 
@@ -1813,6 +2110,7 @@ static void CL_Register (void)
 	Cmd_AddCommand ("exit",				CL_Quit_f,				"Exits");
 	Cmd_AddCommand ("pause",			CL_Pause_f,				"Pauses the game");
 	Cmd_AddCommand ("pingserver",		CL_PingServer_f,		"Sends an info request packet to a server");
+	Cmd_AddCommand ("challengequery",	CL_ChallengeQuery_f,	"Sends getchallenge and prints advertised protocol extras");
 	Cmd_AddCommand ("pinglocal",		CL_PingLocal_f,			"Queries broadcast for an info string");
 	Cmd_AddCommand ("precache",			CL_Precache_f,			"");
 	Cmd_AddCommand ("quit",				CL_Quit_f,				"Exits");

--- a/client/cl_parse.c
+++ b/client/cl_parse.c
@@ -24,6 +24,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 #include "cl_local.h"
 
+static int CL_ParseEntityBits (uint32 *bits);
+static void CL_ParseDelta (entityState_t *from, entityState_t *to, int number, int bits);
+
 char *cl_svcStrings[256] = {
 	"SVC_BAD",
 
@@ -50,8 +53,64 @@ char *cl_svcStrings[256] = {
 	"SVC_FRAME",
 
 	"SVC_ZPACKET",			// new for ENHANCED_PROTOCOL_VERSION
-	"SVC_ZDOWNLOAD"			// new for ENHANCED_PROTOCOL_VERSION
+	"SVC_ZDOWNLOAD",			// new for ENHANCED_PROTOCOL_VERSION
+
+	// Q2Pro protocol 36 extensions
+	"SVC_GAMESTATE",			// new for Q2PRO_PROTOCOL_VERSION
+	"SVC_SETTING",				// new for Q2PRO_PROTOCOL_VERSION
+	"SVC_CONFIGSTRINGSTREAM",	// new for Q2PRO_PROTOCOL_VERSION
+	"SVC_BASELINESTREAM"		// new for Q2PRO_PROTOCOL_VERSION
 };
+
+static void CL_ParseSetting (void)
+{
+	int index;
+	int value;
+
+	// Q2Pro: [long] index [long] value
+	index = MSG_ReadLong (&cls.netMessage);
+	value = MSG_ReadLong (&cls.netMessage);
+
+	// We don't currently implement any server-controlled settings.
+	// Consume and ignore.
+	(void)index;
+	(void)value;
+}
+
+static void CL_ParseGamestate (int cmd)
+{
+	int index;
+	uint32 bits;
+	entityState_t nullState;
+
+	memset (&nullState, 0, sizeof (nullState));
+
+	if (cmd == SVC_GAMESTATE || cmd == SVC_CONFIGSTRINGSTREAM) {
+		for ( ; ; ) {
+			index = MSG_ReadShort (&cls.netMessage);
+			if (index == MAX_CFGSTRINGS)
+				break;
+			if (index < 0 || index >= MAX_CFGSTRINGS)
+				Com_Error (ERR_DROP, "CL_ParseGamestate: bad configstring index %d", index);
+			{
+				char *str = MSG_ReadString (&cls.netMessage);
+				strcpy (cl.configStrings[index], str);
+				CL_CGModule_ParseConfigString (index, str);
+			}
+		}
+	}
+
+	if (cmd == SVC_GAMESTATE || cmd == SVC_BASELINESTREAM) {
+		for ( ; ; ) {
+			index = CL_ParseEntityBits (&bits);
+			if (!index)
+				break;
+			if (index < 0 || index >= MAX_CS_EDICTS)
+				Com_Error (ERR_DROP, "CL_ParseGamestate: bad baseline index %d", index);
+			CL_ParseDelta (&nullState, &cl_baseLines[index], index, bits);
+		}
+	}
+}
 
 /*
 =================
@@ -63,7 +122,7 @@ static void CL_ShowSVCString (char *message)
 	if (cl_shownet->intVal < 2)
 		return;
 
-	Com_Printf (0, "%3i:%s\n", cls.netMessage.readCount-1, message);
+	Com_Printf (0, "%3i/%i:%s\n", cls.netMessage.readCount-1, cls.netMessage.curSize, message);
 }
 
 
@@ -115,7 +174,7 @@ static void CL_ParseDelta (entityState_t *from, entityState_t *to, int number, i
 	// Set everything to the state we are delta'ing from
 	*to = *from;
 
-	if (cls.serverProtocol != ENHANCED_PROTOCOL_VERSION)
+	if (cls.serverProtocol < ENHANCED_PROTOCOL_VERSION)
 		Vec3Copy (from->origin, to->oldOrigin);
 	else if (!(bits & U_OLDORIGIN) && !(from->renderFx & RF_BEAM))
 		Vec3Copy (from->origin, to->oldOrigin);
@@ -184,14 +243,29 @@ static void CL_ParseDelta (entityState_t *from, entityState_t *to, int number, i
 
 	if (bits & U_SOLID)
 	{
-		if (cls.protocolMinorVersion >= MINOR_VERSION_R1Q2_32BIT_SOLID)
+		// Q2Pro (36) always sends long.
+		// R1Q2 (35) sends long if minor version >= MINOR_VERSION_R1Q2_32BIT_SOLID (1905).
+		// Original protocol (34) and older R1Q2 send short.
+		if (cls.serverProtocol == Q2PRO_PROTOCOL_VERSION)
+			to->solid = MSG_ReadLong (&cls.netMessage);
+		else if (cls.serverProtocol == ENHANCED_PROTOCOL_VERSION && cls.protocolMinorVersion >= MINOR_VERSION_R1Q2_32BIT_SOLID)
 			to->solid = MSG_ReadLong (&cls.netMessage);
 		else
 			to->solid = MSG_ReadShort (&cls.netMessage);
 	}
 
-	if (bits & U_VELOCITY && cls.serverProtocol == ENHANCED_PROTOCOL_VERSION)
-		MSG_ReadPos (&cls.netMessage, to->velocity);
+	if (bits & U_VELOCITY)
+	{
+		if (cls.serverProtocol == ENHANCED_PROTOCOL_VERSION)
+		{
+			// R1Q2 35: Skip velocity - it's not used in deltas
+		}
+		else if (cls.serverProtocol == Q2PRO_PROTOCOL_VERSION)
+		{
+			// Q2PRO 36: Read velocity
+			MSG_ReadPos (&cls.netMessage, to->velocity);
+		}
+	}
 }
 
 /*
@@ -214,7 +288,7 @@ static void CL_ParsePlayerstate (const frame_t *oldFrame, frame_t *newFrame, int
 	int					flags;
 	qBool				enhanced;
 
-	enhanced = (cls.serverProtocol == ENHANCED_PROTOCOL_VERSION);
+	enhanced = (cls.serverProtocol >= ENHANCED_PROTOCOL_VERSION);
 
 	state = &newFrame->playerState;
 
@@ -234,19 +308,21 @@ static void CL_ParsePlayerstate (const frame_t *oldFrame, frame_t *newFrame, int
 
 	// protocol changes
 	if (flags & PS_M_ORIGIN) {
-		if (!enhanced)
-			extraFlags |= EPS_PMOVE_ORIGIN2;
 		state->pMove.origin[0] = MSG_ReadShort (&cls.netMessage);
 		state->pMove.origin[1] = MSG_ReadShort (&cls.netMessage);
+		if (!enhanced)
+			// Protocol 34: Read 3rd component as part of PS_M_ORIGIN
+			extraFlags |= EPS_PMOVE_ORIGIN2;
 	}
 	if (extraFlags & EPS_PMOVE_ORIGIN2)
 		state->pMove.origin[2] = MSG_ReadShort (&cls.netMessage);
 
 	if (flags & PS_M_VELOCITY) {
-		if (!enhanced)
-			extraFlags |= EPS_PMOVE_VELOCITY2;
 		state->pMove.velocity[0] = MSG_ReadShort (&cls.netMessage);
 		state->pMove.velocity[1] = MSG_ReadShort (&cls.netMessage);
+		if (!enhanced)
+			// Protocol 34: Read 3rd component as part of PS_M_VELOCITY
+			extraFlags |= EPS_PMOVE_VELOCITY2;
 	}
 	if (extraFlags & EPS_PMOVE_VELOCITY2)
 		state->pMove.velocity[2] = MSG_ReadShort (&cls.netMessage);
@@ -278,10 +354,11 @@ static void CL_ParsePlayerstate (const frame_t *oldFrame, frame_t *newFrame, int
 
 	// protocol changes
 	if (flags & PS_VIEWANGLES) {
-		if (!enhanced)
-			extraFlags |= EPS_VIEWANGLE2;
 		state->viewAngles[0] = MSG_ReadAngle16 (&cls.netMessage);
 		state->viewAngles[1] = MSG_ReadAngle16 (&cls.netMessage);
+		if (!enhanced)
+			// Protocol 34: Read 3rd component as part of PS_VIEWANGLES
+			extraFlags |= EPS_VIEWANGLE2;
 	}
 	if (extraFlags & EPS_VIEWANGLE2)
 		state->viewAngles[2] = MSG_ReadAngle16 (&cls.netMessage);
@@ -298,9 +375,10 @@ static void CL_ParsePlayerstate (const frame_t *oldFrame, frame_t *newFrame, int
 
 	// protocol changes
 	if (flags & PS_WEAPONFRAME) {
-		if (!enhanced)
-			extraFlags |= EPS_GUNOFFSET|EPS_GUNANGLES;
 		state->gunFrame = MSG_ReadByte (&cls.netMessage);
+		if (!enhanced)
+			// Protocol 34: Read gunOffset and gunAngles as part of PS_WEAPONFRAME
+			extraFlags |= EPS_GUNOFFSET|EPS_GUNANGLES;
 	}
 	if (extraFlags & EPS_GUNOFFSET) {
 		state->gunOffset[0] = MSG_ReadChar (&cls.netMessage) * 0.25f;
@@ -393,11 +471,9 @@ static void CL_ParsePacketEntities (const frame_t *oldFrame, frame_t *newFrame)
 
 	// Delta from the entities present in oldFrame
 	oldIndex = 0;
-	if (oldFrame) {
-		if (oldIndex < oldFrame->numEntities) {
-			oldState = &cl_parseEntities[(oldFrame->parseEntities+oldIndex) & (MAX_PARSEENTITIES_MASK)];
-			oldNum = oldState->number;
-		}
+	if (oldFrame && oldFrame->numEntities > 0) {
+		oldState = &cl_parseEntities[(oldFrame->parseEntities+oldIndex) & (MAX_PARSEENTITIES_MASK)];
+		oldNum = oldState->number;
 	}
 
 	for ( ; ; ) {
@@ -411,7 +487,7 @@ static void CL_ParsePacketEntities (const frame_t *oldFrame, frame_t *newFrame)
 		if (!newNum)
 			break;
 
-		while (oldNum < newNum) {
+		while (oldFrame && oldNum < newNum) {
 			// One or more entities from the old packet are unchanged
 			if (cl_shownet->intVal == 3)
 				Com_Printf (0, "   unchanged: %i\n", oldNum);
@@ -434,13 +510,15 @@ static void CL_ParsePacketEntities (const frame_t *oldFrame, frame_t *newFrame)
 			if (oldNum != newNum)
 				Com_DevPrintf (PRNT_WARNING, "U_REMOVE: oldNum != newNum\n");
 
-			oldIndex++;
+			if (oldFrame) {
+				oldIndex++;
 
-			if (oldIndex >= oldFrame->numEntities)
-				oldNum = 99999;
-			else {
-				oldState = &cl_parseEntities[(oldFrame->parseEntities+oldIndex) & (MAX_PARSEENTITIES_MASK)];
-				oldNum = oldState->number;
+				if (oldIndex >= oldFrame->numEntities)
+					oldNum = 99999;
+				else {
+					oldState = &cl_parseEntities[(oldFrame->parseEntities+oldIndex) & (MAX_PARSEENTITIES_MASK)];
+					oldNum = oldState->number;
+				}
 			}
 			continue;
 		}
@@ -451,13 +529,15 @@ static void CL_ParsePacketEntities (const frame_t *oldFrame, frame_t *newFrame)
 				Com_Printf (0, "   delta: %i\n", newNum);
 			CL_DeltaEntity (newFrame, newNum, oldState, bits);
 
-			oldIndex++;
+			if (oldFrame) {
+				oldIndex++;
 
-			if (oldIndex >= oldFrame->numEntities)
-				oldNum = 99999;
-			else {
-				oldState = &cl_parseEntities[(oldFrame->parseEntities+oldIndex) & (MAX_PARSEENTITIES_MASK)];
-				oldNum = oldState->number;
+				if (oldIndex >= oldFrame->numEntities)
+					oldNum = 99999;
+				else {
+					oldState = &cl_parseEntities[(oldFrame->parseEntities+oldIndex) & (MAX_PARSEENTITIES_MASK)];
+					oldNum = oldState->number;
+				}
 			}
 			continue;
 		}
@@ -473,7 +553,7 @@ static void CL_ParsePacketEntities (const frame_t *oldFrame, frame_t *newFrame)
 	}
 
 	// Any remaining entities in the old frame are copied over
-	while (oldNum != 99999) {
+	while (oldFrame && oldNum != 99999) {
 		// One or more entities from the old packet are unchanged
 		if (cl_shownet->intVal == 3)
 			Com_Printf (0, "   unchanged: %i\n", oldNum);
@@ -510,7 +590,7 @@ static void CL_ParseFrame (int extraBits)
 
 	// Protocol updates
 	serverFrame = MSG_ReadLong (&cls.netMessage);
-	if (cls.serverProtocol != ENHANCED_PROTOCOL_VERSION) {
+	if (cls.serverProtocol < ENHANCED_PROTOCOL_VERSION) {
 		cl.frame.serverFrame = serverFrame;
 		cl.frame.deltaFrame = MSG_ReadLong (&cls.netMessage);
 	}
@@ -545,7 +625,7 @@ static void CL_ParseFrame (int extraBits)
 		data = MSG_ReadByte (&cls.netMessage);
 
 		//r1: HACK to get extra 4 bits of otherwise unused data
-		if (cls.serverProtocol == ENHANCED_PROTOCOL_VERSION) {
+		if (cls.serverProtocol >= ENHANCED_PROTOCOL_VERSION) {
 			cl.surpressCount = (data & 0x0F);
 			extraFlags |= (data & 0xF0) >> 4;
 		}
@@ -569,14 +649,17 @@ static void CL_ParseFrame (int extraBits)
 		if (!oldFrame->valid) {
 			// Should never happen
 			Com_Printf (PRNT_ERROR, "Delta from invalid frame (not supposed to happen!).\n");
+			oldFrame = NULL;  // Don't use invalid frame for delta
 		}
-		if (oldFrame->serverFrame != cl.frame.deltaFrame) {
+		else if (oldFrame->serverFrame != cl.frame.deltaFrame) {
 			// The frame that the server did the delta from
 			// is too old, so we can't reconstruct it properly
 			Com_DevPrintf (PRNT_WARNING, "Delta frame too old.\n");
+			oldFrame = NULL;  // Don't use stale frame for delta
 		}
 		else if (cl.parseEntities-oldFrame->parseEntities > MAX_PARSE_ENTITIES-128) {
 			Com_DevPrintf (PRNT_WARNING, "Delta parseEntities too old.\n");
+			oldFrame = NULL;  // Don't use frame with stale entities
 		}
 		else
 			cl.frame.valid = qTrue;	// Valid delta parse
@@ -587,7 +670,7 @@ static void CL_ParseFrame (int extraBits)
 	MSG_ReadData (&cls.netMessage, &cl.frame.areaBits, len);
 
 	// Read playerinfo
-	if (cls.serverProtocol != ENHANCED_PROTOCOL_VERSION) {
+	if (cls.serverProtocol < ENHANCED_PROTOCOL_VERSION) {
 		cmd = MSG_ReadByte (&cls.netMessage);
 		CL_ShowSVCString (cl_svcStrings[cmd]);
 		if (cmd != SVC_PLAYERINFO)
@@ -596,7 +679,7 @@ static void CL_ParseFrame (int extraBits)
 	CL_ParsePlayerstate (oldFrame, &cl.frame, extraFlags);
 
 	// Read packet entities
-	if (cls.serverProtocol != ENHANCED_PROTOCOL_VERSION) {
+	if (cls.serverProtocol < ENHANCED_PROTOCOL_VERSION) {
 		cmd = MSG_ReadByte (&cls.netMessage);
 		CL_ShowSVCString (cl_svcStrings[cmd]);
 		if (cmd != SVC_PACKETENTITIES)
@@ -683,7 +766,7 @@ static qBool CL_ParseServerData (void)
 		Com_Error (ERR_DROP, "CL_ParseServerData: invalid attractLoop %d", cl.attractLoop);
 
 	// BIG HACK to let demos from release work with the 3.0x patch!!!
-	if (i != ORIGINAL_PROTOCOL_VERSION && i != ENHANCED_PROTOCOL_VERSION && i != 26 && !cl.attractLoop)
+	if (i != ORIGINAL_PROTOCOL_VERSION && i != ENHANCED_PROTOCOL_VERSION && i != Q2PRO_PROTOCOL_VERSION && i != 26 && !cl.attractLoop)
 		Com_Error (ERR_DROP, "Server is using unknown protocol %i.", i);
 
 	// Game directory
@@ -731,6 +814,31 @@ static qBool CL_ParseServerData (void)
 			cl.strafeHack = qFalse;
 
 		cls.protocolMinorVersion = newVersion;
+	}
+	else if (cls.serverProtocol == Q2PRO_PROTOCOL_VERSION) {
+		// Authoritative Q2Pro layout (see q2pro SV_New_f):
+		// [short] minor
+		// [byte] server state (always present; meaning varies by minor)
+		// then either:
+		//   [short] protocol flags (minor >= MINOR_VERSION_Q2PRO_EXTENDED_LIMITS)
+		//   or [byte][byte][byte] legacy hacks: strafehack, qwmode, waterhack
+		cl.enhancedServer = 0;
+		newVersion = MSG_ReadShort (&cls.netMessage);
+		cls.protocolMinorVersion = newVersion;
+
+		// always present (but we only really care on newer minors)
+		(void)MSG_ReadByte (&cls.netMessage);
+
+		if (newVersion >= MINOR_VERSION_Q2PRO_EXTENDED_LIMITS) {
+			int flags = MSG_ReadShort (&cls.netMessage);
+			cl.strafeHack = (flags & Q2PRO_PF_STRAFEJUMP_HACK) ? qTrue : qFalse;
+			// We currently ignore other Q2Pro flags.
+		}
+		else {
+			cl.strafeHack = MSG_ReadByte (&cls.netMessage) ? qTrue : qFalse;
+			(void)MSG_ReadByte (&cls.netMessage);
+			(void)MSG_ReadByte (&cls.netMessage);
+		}
 	}
 	else {
 		cl.enhancedServer = 0;
@@ -909,8 +1017,8 @@ void CL_ParseZPacket (void)
 	compressedLen = MSG_ReadShort (&cls.netMessage);
 	uncompressedLen = MSG_ReadShort (&cls.netMessage);
 
-	if (cls.serverProtocol != ENHANCED_PROTOCOL_VERSION)
-		Com_Error (ERR_DROP, "CL_ParseZPacket: SVC_ZPACKET -requires- ENHANCED_PROTOCOL_VERSION");
+	if (cls.serverProtocol != ENHANCED_PROTOCOL_VERSION && cls.serverProtocol != Q2PRO_PROTOCOL_VERSION)
+		Com_Error (ERR_DROP, "CL_ParseZPacket: SVC_ZPACKET requires protocol 35 or 36");
 
 	if (uncompressedLen <= 0)
 		Com_Error (ERR_DROP, "CL_ParseZPacket: uncompressedLen <= 0");
@@ -997,10 +1105,23 @@ void CL_ParseServerMessage (void)
 			break;
 		}
 
-		//r1: more hacky bit stealing in the name of bandwidth
-		extraBits = cmd & 0xE0;
-		cmd &= 0x1F;
-		CL_ShowSVCString (cl_svcStrings[cmd]);
+		extraBits = 0;
+		// Both Q2Pro (36) and R1Q2 (35) use packed 5-bit svc opcode + 3 extra bits
+		// From R1Q2 source: "r1: more hacky bit stealing in the name of bandwidth"
+		if (cls.serverProtocol == Q2PRO_PROTOCOL_VERSION) {
+			// Q2Pro rule: extra bits are only valid for svc_frame (5-bit packed encoding)
+			if ((cmd & 0xE0) && ((cmd & 0x1F) != SVC_FRAME)) {
+				Com_Error (ERR_DROP, "CL_ParseServerMessage: Illegible server message (extra bits on cmd %d)", cmd & 0x1F);
+			}
+			extraBits = cmd & 0xE0;
+			cmd &= 0x1F;
+		}
+		else if (cls.serverProtocol == ENHANCED_PROTOCOL_VERSION) {
+			// R1Q2: Always unpacks all commands - extraBits only used for SVC_FRAME
+			extraBits = cmd & 0xE0;
+			cmd &= 0x1F;
+		}
+		CL_ShowSVCString (cl_svcStrings[cmd] ? cl_svcStrings[cmd] : "SVC_<unknown>");
 
 		//
 		// These are private to the client and server
@@ -1131,6 +1252,44 @@ void CL_ParseServerMessage (void)
 			CL_ParseDownload (qTrue);
 			break;
 
+		case SVC_PLAYERUPDATE:
+			// R1Q2-specific: svc_playerupdate (cmd 23) - player position updates
+			// This is NOT the same as Q2Pro's SVC_GAMESTATE which is also cmd 23
+			if (cls.serverProtocol == ENHANCED_PROTOCOL_VERSION) {
+				// R1Q2 player updates sent between frames for smoother player movement
+				// Format: framenum (long), then for each player that was in that frame: origin (3 shorts)
+				// 
+				// We need to figure out how many player positions follow. According to R1Q2:
+				// - The server iterates through all entities in the frame
+				// - For each entity where number <= maxclients, it writes position
+				// - The client must do the same iteration to know how many to read
+				//
+				// For now, since we don't properly track player update requests (CLSET_PLAYERUPDATE_REQUESTS),
+				// just skip this entire message by reading the framenum.
+				// If server sends player positions, they'll be misread and cause issues.
+				// But typically the server only sends these if client requests them.
+				MSG_ReadLong (&cls.netMessage); // framenum - discard
+				
+				// TODO: Properly implement player updates by tracking which entities
+				// in the referenced frame are players and reading their positions
+				Com_DevPrintf (0, "SVC_PLAYERUPDATE received but not fully implemented\n");
+			}
+			break;
+
+		case SVC_GAMESTATE:
+		case SVC_CONFIGSTRINGSTREAM:
+		case SVC_BASELINESTREAM:
+			if (cls.serverProtocol != Q2PRO_PROTOCOL_VERSION)
+				Com_Error (ERR_DROP, "CL_ParseServerMessage: Q2Pro gamestate stream requires protocol 36");
+			CL_ParseGamestate (cmd);
+			break;
+
+		case SVC_SETTING:
+			if (cls.serverProtocol < ENHANCED_PROTOCOL_VERSION)
+				Com_Error (ERR_DROP, "CL_ParseServerMessage: SVC_SETTING requires protocol 35+");
+			CL_ParseSetting ();
+			break;
+
 		default:
 			CL_WriteDemoMessageChunk (cls.netMessage.data + oldReadCount, cls.netMessage.readCount - oldReadCount, qFalse);
 			if (CL_CGModule_ParseServerMessage (cmd))
@@ -1138,11 +1297,11 @@ void CL_ParseServerMessage (void)
 
 			// Unknown to the client and CGame failed to parse it so...
 			{
-				const char *cmdStr = (cmd >= 0 && cmd < 256) ? cl_svcStrings[cmd] : "SVC_<invalid>";
+				const char *cmdStr = (cmd >= 0 && cmd < 256 && cl_svcStrings[cmd]) ? cl_svcStrings[cmd] : "SVC_<unknown>";
 				const char *lastStr;
 				if (lastCmd == -2)
 					lastStr = "None";
-				else if (lastCmd >= 0 && lastCmd < 256)
+				else if (lastCmd >= 0 && lastCmd < 256 && cl_svcStrings[lastCmd])
 					lastStr = cl_svcStrings[lastCmd];
 				else
 					lastStr = "SVC_<invalid>";

--- a/common/net_chan.c
+++ b/common/net_chan.c
@@ -158,7 +158,7 @@ void Netchan_Setup (netSrc_t sock, netChan_t *chan, netAdr_t *adr, int protocol,
 	chan->sock = sock;
 	chan->remoteAddress = *adr;
 
-	if (protocol == ENHANCED_PROTOCOL_VERSION) {
+	if (protocol == ENHANCED_PROTOCOL_VERSION || protocol == Q2PRO_PROTOCOL_VERSION) {
 		if (msgLen) {
 			if (msgLen > MAX_CL_USABLEMSG)
 				Com_Error (ERR_DROP, "Netchan_Setup: msgLen > MAX_CL_USABLEMSG (%i > %i)", msgLen, MAX_CL_USABLEMSG);
@@ -169,7 +169,8 @@ void Netchan_Setup (netSrc_t sock, netChan_t *chan, netAdr_t *adr, int protocol,
 			msgLen = MAX_SV_USABLEMSG;
 		}
 
-		qPort &= 0xff;
+		// Protocol 35 uses a byte qport on the wire. Protocol 36 handling is server-dependent,
+		// so we keep the full qPort value here and only truncate when serializing.
 	}
 	else {
 		MSG_Init (&chan->message, chan->messageBuff, MAX_SV_USABLEMSG);
@@ -245,7 +246,7 @@ int Netchan_Transmit (netChan_t *chan, size_t length, byte *data)
 	}
 
 	// Write the packet header
-	if (chan->protocol == ENHANCED_PROTOCOL_VERSION)
+	if (chan->protocol == ENHANCED_PROTOCOL_VERSION || chan->protocol == Q2PRO_PROTOCOL_VERSION)
 		MSG_Init (&send, sendBuf, MAX_CL_MSGLEN);
 	else
 		MSG_Init (&send, sendBuf, MAX_SV_MSGLEN);
@@ -259,11 +260,11 @@ int Netchan_Transmit (netChan_t *chan, size_t length, byte *data)
 	MSG_WriteLong (&send, w1);
 	MSG_WriteLong (&send, w2);
 
-	// Send the qport if we are a client
+	// Send the qport if we are a client (byte for enhanced protocols)
 	if (chan->sock == NS_CLIENT) {
-		if (chan->protocol != ENHANCED_PROTOCOL_VERSION)
+		if (chan->protocol == ORIGINAL_PROTOCOL_VERSION)
 			MSG_WriteShort (&send, chan->qPort);
-		else if (chan->qPort)
+		else
 			MSG_WriteByte (&send, chan->qPort & 0xff);
 	}
 

--- a/common/protocol.h
+++ b/common/protocol.h
@@ -32,6 +32,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #define UPDATE_BACKUP		16	// copies of entityState_t to keep buffered must be power of two
 #define UPDATE_MASK			(UPDATE_BACKUP-1)
 
+#define ORIGINAL_PROTOCOL_VERSION	34
+#define ENHANCED_PROTOCOL_VERSION	35
+#define Q2PRO_PROTOCOL_VERSION		36
+
 //
 // client to server
 //

--- a/shared/infostrings.c
+++ b/shared/infostrings.c
@@ -200,7 +200,7 @@ qBool Info_Validate (char *s)
 Info_SetValueForKey
 ==================
 */
-void Info_SetValueForKey (char *s, char *key, char *value)
+void Info_SetValueForKey (char *s, const char *key, const char *value)
 {
 	char	newPair[MAX_INFO_STRING], *v;
 	int		c;

--- a/shared/shared.h
+++ b/shared/shared.h
@@ -247,11 +247,27 @@ typedef enum {qFalse, qTrue}	qBool;
 #define ORIGINAL_PROTOCOL_VERSION		34
 
 #define ENHANCED_PROTOCOL_VERSION		35
+#define Q2PRO_PROTOCOL_VERSION			36
 #define ENHANCED_COMPATIBILITY_NUMBER	1905
 
 #define MINOR_VERSION_R1Q2_BASE			1903
 #define MINOR_VERSION_R1Q2_UCMD_UPDATES	1904
 #define	MINOR_VERSION_R1Q2_32BIT_SOLID	1905
+
+// Q2Pro (protocol 36) minor versions (see q2pro protocol.h)
+#define MINOR_VERSION_Q2PRO_MINIMUM		1015
+#define MINOR_VERSION_Q2PRO_SERVER_STATE	1019
+#define MINOR_VERSION_Q2PRO_ZLIB_DOWNLOADS	1021
+#define MINOR_VERSION_Q2PRO_EXTENDED_LIMITS	1024
+#define MINOR_VERSION_Q2PRO_EXTENDED_LIMITS_2	1025
+#define MINOR_VERSION_Q2PRO_CURRENT		1026
+
+// Q2Pro protocol flags (protocol-36 serverdata tail, minor >= MINOR_VERSION_Q2PRO_EXTENDED_LIMITS)
+#define Q2PRO_PF_STRAFEJUMP_HACK	(1<<0)
+#define Q2PRO_PF_QW_MODE		(1<<1)
+#define Q2PRO_PF_WATERJUMP_HACK		(1<<2)
+#define Q2PRO_PF_EXTENSIONS		(1<<3)
+#define Q2PRO_PF_EXTENSIONS_2		(1<<4)
 
 //
 // server to client
@@ -290,6 +306,13 @@ enum svcTypes {
 
 	SVC_ZPACKET,				// new for ENHANCED_PROTOCOL_VERSION
 	SVC_ZDOWNLOAD,				// new for ENHANCED_PROTOCOL_VERSION
+	SVC_PLAYERUPDATE,			// new for ENHANCED_PROTOCOL_VERSION (R1Q2 only, cmd 23)
+	SVC_SETTING,				// new for ENHANCED_PROTOCOL_VERSION (R1Q2 cmd 24, Q2Pro cmd 25)
+
+	// Q2Pro protocol 36 extensions (note: SVC_GAMESTATE conflicts with R1Q2's SVC_PLAYERUPDATE at cmd 23)
+	SVC_GAMESTATE,				// new for Q2PRO_PROTOCOL_VERSION
+	SVC_CONFIGSTRINGSTREAM,	// new for Q2PRO_PROTOCOL_VERSION
+	SVC_BASELINESTREAM,		// new for Q2PRO_PROTOCOL_VERSION
 
 	SVC_MAX
 };
@@ -710,7 +733,7 @@ char	*Q_VarArgs (char *format, ...);
 void	Info_Print (char *s);
 char	*Info_ValueForKey (char *s, char *key);
 void	Info_RemoveKey (char *s, char *key);
-void	Info_SetValueForKey (char *s, char *key, char *value);
+void	Info_SetValueForKey (char *s, const char *key, const char *value);
 qBool	Info_Validate (char *s);
 
 /*


### PR DESCRIPTION
- Fix playerstate parsing to read only 2 components for enhanced protocols (X,Y inline; Z via extraFlags EPS_M_ORIGIN2, EPS_M_VELOCITY2, etc.)
- Fix R1Q2 connect packet format with msgLen and minor version 1905
- Fix U_SOLID to read 32-bit for R1Q2 with minor version >= 1905
- Add SVC_PLAYERUPDATE handler for R1Q2 delta player updates
-  Fix window mode to full screen SDL2 bug that locked machine 
- Fix unexpected download packet handling to skip payload bytes
- Add protocol auto-detection preferring Q2Pro > R1Q2 > Original
- Define ENHANCED_COMPATIBILITY_NUMBER and version constants
- Add ability to negotiate on protocol 34,35,36 servers

Tested successfully connecting to R1Q2 server (23.227.170.222:27916) with protocol 35, zlib compression, and optimized usercmds.

Tested local q2pro windows server successfully 